### PR TITLE
Specify targets from browserlist to webpack

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -44,6 +44,8 @@ if (!Object.keys(buildFiles).length) {
 const isProduction = process.env.NODE_ENV === 'production';
 const mode = isProduction ? 'production' : 'development';
 
+const defaultTargets = ['> 1%', 'ie >= 11', 'Firefox ESR', 'last 2 versions'];
+
 const cssLoaders = [
 	{
 		loader: MiniCSSExtractPlugin.loader,
@@ -72,6 +74,7 @@ const config = {
 	devtool: isProduction ? false : 'source-map',
 	mode,
 	entry: buildFiles,
+	target: `browserslist:${defaultTargets.join(', ')}`,
 	output: {
 		path: path.resolve(process.cwd(), 'dist'),
 		filename: (pathData) => {
@@ -115,7 +118,7 @@ const config = {
 								presets: [
 									[
 										require.resolve('@10up/babel-preset-default'),
-										{ wordpress: true },
+										{ wordpress: true, targets: defaultTargets },
 									],
 								],
 							}),


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Fixes #34 by telling webpack to use the same target browsers that babel is using.

### Alternate Designs

We could also just specify `target: ['web', 'es5']` but making sure babel and webpack are working off the same base of browsers feels more consistent and less error-prone.

### Benefits

Code will work on IE11

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. Using `npm link` tested the changes on the scaffold 
2. Manually inspecting the compiled output and make sure it does not include any generated code not supported by our target browsers.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#34 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Fixed: Fixes a bug where webpack was not targeting the same browsers as babel, causing code to not run on older browsers like IE 11.
