### PR TITLE
Disable webpack css-loader url resolution

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -54,6 +54,8 @@ const cssLoaders = [
 		loader: require.resolve('css-loader'),
 		options: {
 			sourceMap: !isProduction,
+			// Local files like fonts etc. are copied using CopyWebpackPlugin.
+			url: false,
 		},
 	},
 	{


### PR DESCRIPTION
### Description of the Change

Fixes #38 by disabling url resolution in Webpack's css-loader.

### Alternate Designs

### Benefits

Paths to local files in stylesheets will not break the build process.

### Possible Drawbacks

### Verification Process

Tested the changes in a fresh scaffold installation.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#38 

### Changelog Entry

Fixed: Fix a bug where relative paths to local files in stylesheets would cause errors in the build process.
