### PR TITLE
Fix postcss-editor-styles processing

### DIFF
--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -1,49 +1,54 @@
-module.exports = ( { file, options, env } ) => ( { /* eslint-disable-line */
-	plugins: {
-		'postcss-import': {},
-		'postcss-mixins': {},
-		'postcss-nesting': {},
-		'postcss-preset-env': {
-			stage: 0,
-			autoprefixer: {
-				grid: true,
+const path = require('path');
+
+module.exports = ( { file, options, env } ) => { /* eslint-disable-line */
+	const config = {
+		plugins: {
+			'postcss-import': {},
+			'postcss-mixins': {},
+			'postcss-nesting': {},
+			'postcss-preset-env': {
+				stage: 0,
+				autoprefixer: {
+					grid: true,
+				},
 			},
+			'postcss-object-fit-images': {},
 		},
-		'postcss-object-fit-images': {},
-		// Prefix editor styles with class `editor-styles-wrapper`.
-		'postcss-editor-styles': (file) =>
-			file.basename === 'editor-style.css'
-				? {
-						scopeTo: '.editor-styles-wrapper',
-						ignore: [
-							':root',
-							'.edit-post-visual-editor.editor-styles-wrapper',
-							'.wp-toolbar',
-						],
-						remove: ['html', ':disabled', '[readonly]', '[disabled]'],
-						tags: ['button', 'input', 'label', 'select', 'textarea', 'form'],
-				  }
-				: false,
-		// Minify style on production using cssano.
-		cssnano:
-			env === 'production'
-				? {
-						preset: [
-							'default',
-							{
-								autoprefixer: false,
-								calc: {
-									precision: 8,
-								},
-								convertValues: true,
-								discardComments: {
-									removeAll: true,
-								},
-								mergeLonghand: false,
-								zindex: false,
-							},
-						],
-				  }
-				: false,
-	},
-});
+	};
+
+	// Only load postcss-editor-styles plugin when we're processing the editor-style.css file.
+	if (path.basename(file) === 'editor-style.css') {
+		config.plugins['postcss-editor-styles'] = {
+			scopeTo: '.editor-styles-wrapper',
+			ignore: [
+				':root',
+				'.edit-post-visual-editor.editor-styles-wrapper',
+				'.wp-toolbar',
+			],
+			remove: ['html', ':disabled', '[readonly]', '[disabled]'],
+			tags: ['button', 'input', 'label', 'select', 'textarea', 'form'],
+		};
+	}
+
+	config.plugins.cssnano = env === 'production'
+		? {
+			preset: [
+				'default',
+				{
+					autoprefixer: false,
+					calc: {
+						precision: 8,
+					},
+					convertValues: true,
+					discardComments: {
+						removeAll: true,
+					},
+					mergeLonghand: false,
+					zindex: false,
+				},
+			],
+		}
+		: false;
+
+	return config;
+};

--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -20,35 +20,32 @@ module.exports = ( { file, options, env } ) => { /* eslint-disable-line */
 	if (path.basename(file) === 'editor-style.css') {
 		config.plugins['postcss-editor-styles'] = {
 			scopeTo: '.editor-styles-wrapper',
-			ignore: [
-				':root',
-				'.edit-post-visual-editor.editor-styles-wrapper',
-				'.wp-toolbar',
-			],
+			ignore: [':root', '.edit-post-visual-editor.editor-styles-wrapper', '.wp-toolbar'],
 			remove: ['html', ':disabled', '[readonly]', '[disabled]'],
 			tags: ['button', 'input', 'label', 'select', 'textarea', 'form'],
 		};
 	}
 
-	config.plugins.cssnano = env === 'production'
-		? {
-			preset: [
-				'default',
-				{
-					autoprefixer: false,
-					calc: {
-						precision: 8,
-					},
-					convertValues: true,
-					discardComments: {
-						removeAll: true,
-					},
-					mergeLonghand: false,
-					zindex: false,
-				},
-			],
-		}
-		: false;
+	config.plugins.cssnano =
+		env === 'production'
+			? {
+					preset: [
+						'default',
+						{
+							autoprefixer: false,
+							calc: {
+								precision: 8,
+							},
+							convertValues: true,
+							discardComments: {
+								removeAll: true,
+							},
+							mergeLonghand: false,
+							zindex: false,
+						},
+					],
+			  }
+			: false;
 
 	return config;
 };


### PR DESCRIPTION
### Description of the Change

Only load and run the `postcss-editor-styles` plugin when processing `editor-style.css`

### Alternate Designs

N/A

### Benefits

Only the `editor-style.css` file will get the `.editor-styles-wrapper` class.

### Possible Drawbacks

None

### Verification Process

Tested locally on project using wp-scaffold

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#40 

### Changelog Entry

- Fixed issue with editor class being appended to all styles.
