### PR TITLE
Feature/add scss support

### DIFF
--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
+## 1.0.1
+- Added support for SCSS and Sass files.
+
 ## 1.0.0
 
 - Adds support for authoring libraries.

--- a/packages/toolkit/config/__tests__/__snapshots__/webpack.config.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack.config.js.snap
@@ -324,7 +324,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/node_modules/@10up/babel-preset-default/index.js",
+                  "/packages/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -482,7 +482,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/node_modules/@10up/babel-preset-default/index.js",
+                  "/packages/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -649,7 +649,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/node_modules/@10up/babel-preset-default/index.js",
+                  "/packages/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -802,7 +802,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/node_modules/@10up/babel-preset-default/index.js",
+                  "/packages/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",

--- a/packages/toolkit/config/__tests__/__snapshots__/webpack.config.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack.config.js.snap
@@ -72,6 +72,33 @@ Object {
         ],
       },
       Object {
+        "test": /\\\\\\.\\(sc\\|sa\\)ss\\$/,
+        "use": Array [
+          Object {
+            "loader": "/node_modules/mini-css-extract-plugin/dist/loader.js",
+          },
+          Object {
+            "loader": "/node_modules/css-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+              "url": true,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
+            },
+          },
+          Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+        ],
+      },
+      Object {
         "test": /\\\\\\.\\{jpg,jpeg,png,gif,svg,eot,ttf,woff,woff2\\}/,
         "type": "asset/resource",
       },
@@ -95,7 +122,7 @@ Object {
     ESLintWebpackPlugin: {"extensions":"js","emitError":true,"emitWarning":true,"failOnError":false,"fix":false},
     MiniCssExtractPlugin: {"ignoreOrder":false,"chunkFilename":"[id].css"},
     ImageminPlugin: {"disable":true,"imageminOptions":{"plugins":[null,null,null,null]},"externalImages":{"context":".","sources":[],"destination":".","fileName":null},"cacheFolder":null},
-    StylelintWebpackPlugin: {"files":"**/*.css","stylelintPath":"stylelint","context":"/assets","allowEmptyInput":true},
+    StylelintWebpackPlugin: {"files":"**/*.(s(c|a)ss|css)","stylelintPath":"stylelint","context":"/assets","allowEmptyInput":true},
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     CleanExtractedDeps: {},
   ],
@@ -179,6 +206,33 @@ Object {
           },
         ],
       },
+      Object {
+        "test": /\\\\\\.\\(sc\\|sa\\)ss\\$/,
+        "use": Array [
+          Object {
+            "loader": "/node_modules/mini-css-extract-plugin/dist/loader.js",
+          },
+          Object {
+            "loader": "/node_modules/css-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+              "url": false,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
+            },
+          },
+          Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+        ],
+      },
     ],
   },
   "optimization": Object {
@@ -204,7 +258,7 @@ Object {
     MiniCssExtractPlugin: {"ignoreOrder":false,"chunkFilename":"[id].css"},
     CopyPlugin: {},
     ImageminPlugin: {"disable":true,"imageminOptions":{"plugins":[null,null,null,null]},"externalImages":{"context":".","sources":[],"destination":".","fileName":null},"cacheFolder":null},
-    StylelintWebpackPlugin: {"files":"**/*.css","stylelintPath":"stylelint","context":"/assets2","allowEmptyInput":true},
+    StylelintWebpackPlugin: {"files":"**/*.(s(c|a)ss|css)","stylelintPath":"stylelint","context":"/assets2","allowEmptyInput":true},
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     DependencyExtractionWebpackPlugin: {"combineAssets":false,"combinedOutputFile":null,"injectPolyfill":true,"outputFormat":"php","useDefaults":true},
     CleanExtractedDeps: {},
@@ -270,7 +324,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/packages/babel-preset-default/index.js",
+                  "/node_modules/@10up/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -319,6 +373,35 @@ Object {
         ],
       },
       Object {
+        "test": /\\\\\\.\\(sc\\|sa\\)ss\\$/,
+        "use": Array [
+          Object {
+            "loader": "/node_modules/mini-css-extract-plugin/dist/loader.js",
+          },
+          Object {
+            "loader": "/node_modules/css-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+              "url": true,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {
+                "config": "/config/postcss.config.js",
+              },
+            },
+          },
+          Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+        ],
+      },
+      Object {
         "test": /\\\\\\.\\{jpg,jpeg,png,gif,svg,eot,ttf,woff,woff2\\}/,
         "type": "asset/resource",
       },
@@ -342,7 +425,7 @@ Object {
     ESLintWebpackPlugin: {"extensions":"js","emitError":true,"emitWarning":true,"failOnError":false,"fix":false},
     MiniCssExtractPlugin: {"ignoreOrder":false,"chunkFilename":"[id].css"},
     ImageminPlugin: {"disable":true,"imageminOptions":{"plugins":[null,null,null,null]},"externalImages":{"context":".","sources":[],"destination":".","fileName":null},"cacheFolder":null},
-    StylelintWebpackPlugin: {"files":"**/*.css","stylelintPath":"stylelint","context":"/assets","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
+    StylelintWebpackPlugin: {"files":"**/*.(s(c|a)ss|css)","stylelintPath":"stylelint","context":"/assets","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     CleanExtractedDeps: {},
   ],
@@ -399,7 +482,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/packages/babel-preset-default/index.js",
+                  "/node_modules/@10up/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -448,6 +531,35 @@ Object {
         ],
       },
       Object {
+        "test": /\\\\\\.\\(sc\\|sa\\)ss\\$/,
+        "use": Array [
+          Object {
+            "loader": "/node_modules/mini-css-extract-plugin/dist/loader.js",
+          },
+          Object {
+            "loader": "/node_modules/css-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+              "url": true,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {
+                "config": "/config/postcss.config.js",
+              },
+            },
+          },
+          Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+        ],
+      },
+      Object {
         "test": /\\\\\\.\\{jpg,jpeg,png,gif,svg,eot,ttf,woff,woff2\\}/,
         "type": "asset/resource",
       },
@@ -471,7 +583,7 @@ Object {
     ESLintWebpackPlugin: {"extensions":"js","emitError":true,"emitWarning":true,"failOnError":false,"fix":false},
     MiniCssExtractPlugin: {"ignoreOrder":false,"chunkFilename":"[id].css"},
     ImageminPlugin: {"disable":true,"imageminOptions":{"plugins":[null,null,null,null]},"externalImages":{"context":".","sources":[],"destination":".","fileName":null},"cacheFolder":null},
-    StylelintWebpackPlugin: {"files":"**/*.css","stylelintPath":"stylelint","context":"/assets","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
+    StylelintWebpackPlugin: {"files":"**/*.(s(c|a)ss|css)","stylelintPath":"stylelint","context":"/assets","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     CleanExtractedDeps: {},
   ],
@@ -537,7 +649,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/packages/babel-preset-default/index.js",
+                  "/node_modules/@10up/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -586,6 +698,35 @@ Object {
         ],
       },
       Object {
+        "test": /\\\\\\.\\(sc\\|sa\\)ss\\$/,
+        "use": Array [
+          Object {
+            "loader": "/node_modules/mini-css-extract-plugin/dist/loader.js",
+          },
+          Object {
+            "loader": "/node_modules/css-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+              "url": true,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {
+                "config": "/config/postcss.config.js",
+              },
+            },
+          },
+          Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+        ],
+      },
+      Object {
         "test": /\\\\\\.\\{jpg,jpeg,png,gif,svg,eot,ttf,woff,woff2\\}/,
         "type": "asset/resource",
       },
@@ -609,7 +750,7 @@ Object {
     ESLintWebpackPlugin: {"extensions":"js","emitError":true,"emitWarning":true,"failOnError":false,"fix":false},
     MiniCssExtractPlugin: {"ignoreOrder":false,"chunkFilename":"[id].css"},
     ImageminPlugin: {"disable":true,"imageminOptions":{"plugins":[null,null,null,null]},"externalImages":{"context":".","sources":[],"destination":".","fileName":null},"cacheFolder":null},
-    StylelintWebpackPlugin: {"files":"**/*.css","stylelintPath":"stylelint","context":"/assets","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
+    StylelintWebpackPlugin: {"files":"**/*.(s(c|a)ss|css)","stylelintPath":"stylelint","context":"/assets","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     CleanExtractedDeps: {},
   ],
@@ -661,7 +802,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/packages/babel-preset-default/index.js",
+                  "/node_modules/@10up/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -712,6 +853,35 @@ Object {
           },
         ],
       },
+      Object {
+        "test": /\\\\\\.\\(sc\\|sa\\)ss\\$/,
+        "use": Array [
+          Object {
+            "loader": "/node_modules/mini-css-extract-plugin/dist/loader.js",
+          },
+          Object {
+            "loader": "/node_modules/css-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+              "url": false,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {
+                "config": "/config/postcss.config.js",
+              },
+            },
+          },
+          Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+        ],
+      },
     ],
   },
   "optimization": Object {
@@ -738,7 +908,7 @@ Object {
     CopyPlugin: {},
     ImageminPlugin: {"disable":true,"imageminOptions":{"plugins":[null,null,null,null]},"externalImages":{"context":".","sources":[],"destination":".","fileName":null},"cacheFolder":null},
     BrowserSyncPlugin: {"reload":false,"name":"bs-webpack-plugin","injectCss":true},
-    StylelintWebpackPlugin: {"files":"**/*.css","stylelintPath":"stylelint","context":"/assets2","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
+    StylelintWebpackPlugin: {"files":"**/*.(s(c|a)ss|css)","stylelintPath":"stylelint","context":"/assets2","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     DependencyExtractionWebpackPlugin: {"combineAssets":false,"combinedOutputFile":null,"injectPolyfill":true,"outputFormat":"php","useDefaults":true},
     CleanExtractedDeps: {},

--- a/packages/toolkit/config/webpack/modules.js
+++ b/packages/toolkit/config/webpack/modules.js
@@ -81,6 +81,18 @@ module.exports = ({
 					: paths.cssLoaderPaths.map((cssPath) => path.resolve(process.cwd(), cssPath)),
 				use: cssLoaders,
 			},
+			{
+				test: /\.(sc|sa)ss$/,
+				use: [
+					...cssLoaders,
+					{
+						loader: require.resolve( 'sass-loader' ),
+						options: {
+							sourceMap: ! isProduction,
+						},
+					},
+				],
+			},
 			// when in package module only include referenced resources
 			isPackage && {
 				test: /\.{jpg,jpeg,png,gif,svg,eot,ttf,woff,woff2}/,

--- a/packages/toolkit/config/webpack/plugins.js
+++ b/packages/toolkit/config/webpack/plugins.js
@@ -80,7 +80,7 @@ module.exports = ({
 		// Lint CSS.
 		new StyleLintPlugin({
 			context: path.resolve(process.cwd(), paths.srcDir),
-			files: '**/*.css',
+			files: '**/*.(s(c|a)ss|css)',
 			allowEmptyInput: true,
 			...(!hasStylelintConfig() && {
 				configFile: fromConfigRoot('stylelint.config.js'),

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -84,6 +84,8 @@
     "read-pkg": "^5.2.0",
     "read-pkg-up": "^1.0.1",
     "resolve-bin": "^0.4.0",
+    "sass": "^1.26.11",
+    "sass-loader": "^10.1.1",
     "stylelint": "^13.9.0",
     "stylelint-webpack-plugin": "^2.1.1",
     "thread-loader": "^3.0.1",

--- a/packages/toolkit/scripts/lint-style.js
+++ b/packages/toolkit/scripts/lint-style.js
@@ -18,7 +18,7 @@ const {
 
 const args = getArgsFromCLI();
 
-const defaultFilesArgs = hasFileArgInCLI() ? [] : ['**/*.css'];
+const defaultFilesArgs = hasFileArgInCLI() ? [] : ['**/*.(s(c|a)ss|css)'];
 
 // See: https://stylelint.io/user-guide/configuration
 const hasLintConfig =

--- a/projects/10up-theme/assets/css/frontend/testing.scss
+++ b/projects/10up-theme/assets/css/frontend/testing.scss
@@ -1,0 +1,7 @@
+.test-class {
+	color: --c-black;
+
+	&.sub-class {
+		color: --c-white;
+	}
+}

--- a/projects/10up-theme/package.json
+++ b/projects/10up-theme/package.json
@@ -34,7 +34,8 @@
       "style": "./assets/css/frontend/style.css",
       "styleguide-style": "./assets/css/styleguide/styleguide.css",
       "core-block-overrides": "./includes/core-block-overrides.js",
-      "example-block": "./includes/blocks/example-block/index.js"
+      "example-block": "./includes/blocks/example-block/index.js",
+      "test-style": "./assets/css/frontend/testing.scss"
     }
   }
 }


### PR DESCRIPTION
### Description of the Change

Adds Sass and SCSS support to the toolkit by adding a new loader to Webpack and allowing stylelint to pick them up.

### Alternate Designs

N/A

### Benefits

Projects utilising SCSS or Sass can use the toolkit

### Possible Drawbacks

None that I'm aware of.

### Verification Process

Added SCSS file to the 10up-theme project that compiles to CSS correctly.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

N/A

### Changelog Entry

- Added support for SCSS and Sass files
