### PR TITLE
Add cache busting to chunk file names

### DIFF
--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
+## 1.0.1
+- Adds cache busting to chunk files generated via Webpack code splitting.
+
 ## 1.0.0
 
 - Adds support for authoring libraries.

--- a/packages/toolkit/config/__tests__/__snapshots__/webpack.config.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack.config.js.snap
@@ -271,7 +271,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/node_modules/@10up/babel-preset-default/index.js",
+                  "/packages/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -400,7 +400,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/node_modules/@10up/babel-preset-default/index.js",
+                  "/packages/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -538,7 +538,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/node_modules/@10up/babel-preset-default/index.js",
+                  "/packages/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -662,7 +662,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/node_modules/@10up/babel-preset-default/index.js",
+                  "/packages/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",

--- a/packages/toolkit/config/__tests__/__snapshots__/webpack.config.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack.config.js.snap
@@ -188,6 +188,7 @@ Object {
     ],
   },
   "output": Object {
+    "chunkFilename": "js/[name].[contenthash].chunk.js",
     "clean": true,
     "filename": function filename(pathData) {
       return buildFiles[pathData.chunk.name].match(/\\/blocks\\//) ? filenames.block : filenames.js;
@@ -270,7 +271,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/packages/babel-preset-default/index.js",
+                  "/node_modules/@10up/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -399,7 +400,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/packages/babel-preset-default/index.js",
+                  "/node_modules/@10up/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -537,7 +538,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/packages/babel-preset-default/index.js",
+                  "/node_modules/@10up/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -661,7 +662,7 @@ Object {
               "configFile": false,
               "presets": Array [
                 Array [
-                  "/packages/babel-preset-default/index.js",
+                  "/node_modules/@10up/babel-preset-default/index.js",
                   Object {
                     "targets": Array [
                       "> 1%",
@@ -721,6 +722,7 @@ Object {
     ],
   },
   "output": Object {
+    "chunkFilename": "js/[name].[contenthash].chunk.js",
     "clean": true,
     "filename": function filename(pathData) {
       return buildFiles[pathData.chunk.name].match(/\\/blocks\\//) ? filenames.block : filenames.js;

--- a/packages/toolkit/config/filenames.config.js
+++ b/packages/toolkit/config/filenames.config.js
@@ -1,5 +1,6 @@
 module.exports = {
 	js: 'js/[name].js',
+	jsChunk: 'js/[name].[contenthash].chunk.js',
 	css: 'css/[name].css',
 	block: 'blocks/[name]/editor.js',
 	blockCSS: 'blocks/[name]/editor.css',

--- a/packages/toolkit/config/webpack/output.js
+++ b/packages/toolkit/config/webpack/output.js
@@ -10,6 +10,7 @@ module.exports = ({ isPackage, projectConfig: { filenames }, buildFiles }) => {
 	return {
 		clean: true,
 		path: path.resolve(process.cwd(), 'dist'),
+		chunkFilename: filenames.jsChunk,
 		filename: (pathData) => {
 			return buildFiles[pathData.chunk.name].match(/\/blocks\//)
 				? filenames.block


### PR DESCRIPTION
### Description of the Change

This change adds the `chunkFilename` option to Weback and a sensible default.

See: https://webpack.js.org/configuration/output/#outputchunkfilename

### Alternate Designs

N/A

### Benefits

One issue we've seen before is that code that utilises webpack code-splitting ends up with chunks like this:

* 23.js
* 24.js
* 25.js

The issue with this is that when they're loaded by webpack, they don't inherit the cache busting value that the main file does. This leads to strange issues where the main JS file has a new version loaded, but the chunk is out of date.

By appending a content hash to the chunk name, we can make sure that they get cache-busted when the content changes, nullifying the cache issue.

### Possible Drawbacks

N/A

### Verification Process

Currently using on a project.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

N/A

### Changelog Entry

- Adds cache busting to chunk files generated via Webpack code splitting.
