### PR TITLE
fix spelling misstake in `homepage` package.json property

### DIFF
--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.1",
   "description": "10up stylelint config for WordPress projects",
   "main": "index.js",
-  "homepage": "https://github.com/10up/10up-toolkit/tree/develop/packages/stylelint-configg#readme",
+  "homepage": "https://github.com/10up/10up-toolkit/tree/develop/packages/stylelint-config#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/10up/10up-toolkit.git"


### PR DESCRIPTION
Fixed `configg` → `config`
