### PR TITLE
Fix empty js file output from css entry

### DIFF
--- a/packages/toolkit/config/__tests__/__snapshots__/webpack.config.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack.config.js.snap
@@ -168,6 +168,7 @@ Object {
     StylelintWebpackPlugin: {"extensions":["css","scss","sass"],"emitError":true,"emitWarning":true,"failOnError":true,"context":"/assets","files":"**/*.(s(c|a)ss|css)","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     CleanExtractedDeps: {},
+    WebpackRemoveEmptyScriptsPlugin: {"verbose":false,"extensions":["css","scss","sass","less","styl"],"scriptExtensions":["js","mjs"],"ignore":[]},
   ],
   "resolve": Object {
     "alias": Object {
@@ -344,6 +345,7 @@ Object {
     StylelintWebpackPlugin: {"extensions":["css","scss","sass"],"emitError":true,"emitWarning":true,"failOnError":true,"context":"/assets","files":"**/*.(s(c|a)ss|css)","allowEmptyInput":true},
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     CleanExtractedDeps: {},
+    WebpackRemoveEmptyScriptsPlugin: {"verbose":false,"extensions":["css","scss","sass","less","styl"],"scriptExtensions":["js","mjs"],"ignore":[]},
   ],
   "resolve": Object {
     "alias": Object {
@@ -509,6 +511,7 @@ Object {
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     DependencyExtractionWebpackPlugin: {"combineAssets":false,"combinedOutputFile":null,"injectPolyfill":true,"outputFormat":"php","useDefaults":true},
     CleanExtractedDeps: {},
+    WebpackRemoveEmptyScriptsPlugin: {"verbose":false,"extensions":["css","scss","sass","less","styl"],"scriptExtensions":["js","mjs"],"ignore":[]},
   ],
   "resolve": Object {
     "alias": Object {
@@ -706,6 +709,7 @@ Object {
     StylelintWebpackPlugin: {"extensions":["css","scss","sass"],"emitError":true,"emitWarning":true,"failOnError":true,"context":"/assets","files":"**/*.(s(c|a)ss|css)","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     CleanExtractedDeps: {},
+    WebpackRemoveEmptyScriptsPlugin: {"verbose":false,"extensions":["css","scss","sass","less","styl"],"scriptExtensions":["js","mjs"],"ignore":[]},
   ],
   "resolve": Object {
     "alias": Object {
@@ -895,6 +899,7 @@ Object {
     StylelintWebpackPlugin: {"extensions":["css","scss","sass"],"emitError":true,"emitWarning":true,"failOnError":true,"context":"/assets","files":"**/*.(s(c|a)ss|css)","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     CleanExtractedDeps: {},
+    WebpackRemoveEmptyScriptsPlugin: {"verbose":false,"extensions":["css","scss","sass","less","styl"],"scriptExtensions":["js","mjs"],"ignore":[]},
   ],
   "resolve": Object {
     "alias": Object {
@@ -1093,6 +1098,7 @@ Object {
     StylelintWebpackPlugin: {"extensions":["css","scss","sass"],"emitError":true,"emitWarning":true,"failOnError":true,"context":"/assets","files":"**/*.(s(c|a)ss|css)","allowEmptyInput":true,"configFile":"/config/stylelint.config.js"},
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     CleanExtractedDeps: {},
+    WebpackRemoveEmptyScriptsPlugin: {"verbose":false,"extensions":["css","scss","sass","less","styl"],"scriptExtensions":["js","mjs"],"ignore":[]},
   ],
   "resolve": Object {
     "alias": Object {
@@ -1281,6 +1287,7 @@ Object {
     WebpackBarPlugin: {"name":"webpack","color":"green","reporters":["basic"],"reporter":null},
     DependencyExtractionWebpackPlugin: {"combineAssets":false,"combinedOutputFile":null,"injectPolyfill":true,"outputFormat":"php","useDefaults":true},
     CleanExtractedDeps: {},
+    WebpackRemoveEmptyScriptsPlugin: {"verbose":false,"extensions":["css","scss","sass","less","styl"],"scriptExtensions":["js","mjs"],"ignore":[]},
   ],
   "resolve": Object {
     "alias": Object {

--- a/packages/toolkit/config/webpack/plugins.js
+++ b/packages/toolkit/config/webpack/plugins.js
@@ -8,6 +8,7 @@ const StyleLintPlugin = require('stylelint-webpack-plugin');
 const WebpackBar = require('webpackbar');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 const CleanExtractedDeps = require('../../utils/clean-extracted-deps');
 
 const { hasStylelintConfig, fromConfigRoot, hasProjectFile } = require('../../utils');
@@ -101,5 +102,6 @@ module.exports = ({
 				injectPolyfill: true,
 			}),
 		new CleanExtractedDeps(),
+		new RemoveEmptyScriptsPlugin(),
 	].filter(Boolean);
 };

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -85,6 +85,7 @@
     "webpack": "^5.41.1",
     "webpack-bundle-analyzer": "^4.4.2",
     "webpack-dev-server": "^3.11.2",
+    "webpack-remove-empty-scripts": "^0.7.1",
     "webpack-sources": "^2.3.0",
     "webpackbar": "^5.0.0-3"
   },


### PR DESCRIPTION
### Description of the Change
This change adds the plugin [webpack-remove-empty-scripts](https://github.com/webdiscus/webpack-remove-empty-scripts) to remove empty scripts generated when we have CSS entries.

### Alternate Designs

### Benefits

It's not necessary extending the webpack config to remove empty scripts.

### Possible Drawbacks

### Verification Process

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes: #90 

### Changelog Entry

Fixed empty scripts output when a CSS entry is added.
