### PR TITLE
Allow all global color values.

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugins: ['stylelint-declaration-use-variable', 'stylelint-order'],
 	rules: {
 		'sh-waqar/declaration-use-variable': [
-			['/color/', { ignoreValues: ['transparent', 'inherit', 'currentColor'] }],
+			['/color/', { ignoreValues: ['currentColor', 'inherit', 'initial', 'transparent', 'unset'] }],
 		],
 		'order/properties-alphabetical-order': true,
 		'function-url-quotes': 'always',


### PR DESCRIPTION
### Description of the Change

This pull request changes the stylelint configuration to allow CSS color properties be set to any global value without using a variable. 

### Alternate Designs

I've made this update to my project's stylelint configuration, but feel that future projects should make use of this update.

### Benefits

Color properties will be able to use `initial` or `unset` without using a variable.

### Possible Drawbacks

Maybe we don't want to allow developers to use `unset` for colors.

### Verification Process

I'm using this updated rule in my current project.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Change Stylelint configuration to allow color properties to use any of the global CSS values without a variable.
