### PR TITLE
Upgrade Stylelint dependencies for `@10up/stylelint-config`

### DIFF
--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
-## [1,1,3]
+## Unreleased (major)
+
+- Drops support of Stylelint 13 (breaking)
+- Updated `@wordpress/stylelint-config` to `20.0.1` (major)
+- Updated `stylelint-order` to `5.0.0` (major)
+
 ## 1.1.3
 - updated dependencies
 - Change Stylelint configuration to allow color properties to use any of the global CSS values without a variable.

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -3,14 +3,15 @@
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
 ## [1,1,3]
+## 1.1.3
 - updated dependencies
 - Change Stylelint configuration to allow color properties to use any of the global CSS values without a variable.
 
-## [1.1.2]
+## 1.1.2
 - Add stylelint support for mixins. Props @rdimascio
 
-## [1.1.1]
+## 1.1.1
 - Fix a bug in the config where it was extending the wrong config.
 
-## [1.1.0]
+## 1.1.0 
 - Updates dependencies

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -32,9 +32,12 @@
   "engines": {
     "node": ">=12"
   },
+  "peerDependencies": {
+    "stylelint": "^14.0.0"
+  },
   "dependencies": {
-    "@wordpress/stylelint-config": "^19.1.0",
+    "@wordpress/stylelint-config": "^20.0.1",
     "stylelint-declaration-use-variable": "^1.7.3",
-    "stylelint-order": "^4.1.0"
+    "stylelint-order": "^5.0.0"
   }
 }


### PR DESCRIPTION
### Description of the Change

This upgrades both `@wordpress/stylelint-config` and `stylelint-order` to their next major which drops support of `stylelint` version `13`. 

This adds a soft `peerDependency` which clearly states the `stylelint` version the rule set supports.

Fixes #138 

### Possible Drawbacks

None, this should be a major release so it's not accidentally pulled.

### Checklist:

- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
