### PR TITLE
Fix how webpack handles addition of new `block.json` files during watch mode

### DIFF
--- a/.changeset/eighty-rivers-remain.md
+++ b/.changeset/eighty-rivers-remain.md
@@ -1,0 +1,5 @@
+---
+"10up-toolkit": patch
+---
+
+Fix how webpack handles addition of new block.json files during watch mode

--- a/packages/toolkit/config/__tests__/__snapshots__/webpack-basic-config.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack-basic-config.js.snap
@@ -4,23 +4,7 @@ exports[`webpack.config.js properly detects user config files in package mode 1`
 Object {
   "devServer": undefined,
   "devtool": "source-map",
-  "entry": Object {
-    "main": Object {
-      "filename": "index.js",
-      "import": "./src/index.js",
-      "library": Object {
-        "type": "commonjs2",
-      },
-    },
-    "umd": Object {
-      "filename": "index.umd.js",
-      "import": "./src/index.js",
-      "library": Object {
-        "name": "componentLibrary",
-        "type": "umd",
-      },
-    },
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },
@@ -188,11 +172,7 @@ exports[`webpack.config.js properly detects user config files in project mode 1`
 Object {
   "devServer": undefined,
   "devtool": "source-map",
-  "entry": Object {
-    "entry1": "entry1.js",
-    "entry2": "entry2.js",
-    "entry3": "entry3.js",
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },
@@ -364,23 +344,7 @@ exports[`webpack.config.js returns proper configs for package config 1`] = `
 Object {
   "devServer": undefined,
   "devtool": "source-map",
-  "entry": Object {
-    "main": Object {
-      "filename": "index.js",
-      "import": "./src/index.js",
-      "library": Object {
-        "type": "commonjs2",
-      },
-    },
-    "umd": Object {
-      "filename": "index.umd.js",
-      "import": "./src/index.js",
-      "library": Object {
-        "name": "componentLibrary",
-        "type": "umd",
-      },
-    },
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },
@@ -571,15 +535,7 @@ exports[`webpack.config.js returns proper configs for package config with common
 Object {
   "devServer": undefined,
   "devtool": "source-map",
-  "entry": Object {
-    "main": Object {
-      "filename": "index.js",
-      "import": "./src/index.js",
-      "library": Object {
-        "type": "commonjs2",
-      },
-    },
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },
@@ -770,23 +726,7 @@ exports[`webpack.config.js returns proper configs for package config with peer d
 Object {
   "devServer": undefined,
   "devtool": "source-map",
-  "entry": Object {
-    "main": Object {
-      "filename": "index.js",
-      "import": "./src/index.js",
-      "library": Object {
-        "type": "commonjs2",
-      },
-    },
-    "umd": Object {
-      "filename": "index.umd.js",
-      "import": "./src/index.js",
-      "library": Object {
-        "name": "componentLibrary",
-        "type": "umd",
-      },
-    },
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },
@@ -978,11 +918,7 @@ exports[`webpack.config.js returns proper configs for project configs 1`] = `
 Object {
   "devServer": undefined,
   "devtool": "source-map",
-  "entry": Object {
-    "entry1": "entry1.js",
-    "entry2": "entry2.js",
-    "entry3": "entry3.js",
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },

--- a/packages/toolkit/config/__tests__/__snapshots__/webpack-cli-arguments.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack-cli-arguments.js.snap
@@ -7,15 +7,7 @@ Object {
     "port": 3000,
   },
   "devtool": "source-map",
-  "entry": Object {
-    "main": Object {
-      "filename": "index.js",
-      "import": "./src/index.js",
-      "library": Object {
-        "type": "commonjs2",
-      },
-    },
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },
@@ -207,9 +199,7 @@ exports[`webpack.config.js allows changing browsersync port 1`] = `
 Object {
   "devServer": undefined,
   "devtool": "source-map",
-  "entry": Object {
-    "entry1": "entry1.js",
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },
@@ -382,9 +372,7 @@ exports[`webpack.config.js includes webpack-bundle-analyzer when using --analyze
 Object {
   "devServer": undefined,
   "devtool": false,
-  "entry": Object {
-    "entry1": "entry1.js",
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },
@@ -557,9 +545,7 @@ exports[`webpack.config.js includes webpack-bundle-analyzer when using --analyze
 Object {
   "devServer": undefined,
   "devtool": "source-map",
-  "entry": Object {
-    "entry1": "entry1.js",
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },
@@ -731,15 +717,7 @@ exports[`webpack.config.js returns proper configs for package config with common
 Object {
   "devServer": undefined,
   "devtool": "source-map",
-  "entry": Object {
-    "main": Object {
-      "filename": "index.js",
-      "import": "./src/index.js",
-      "library": Object {
-        "type": "commonjs2",
-      },
-    },
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },
@@ -930,15 +908,7 @@ exports[`webpack.config.js takes the --target option into account 1`] = `
 Object {
   "devServer": undefined,
   "devtool": "source-map",
-  "entry": Object {
-    "main": Object {
-      "filename": "index.js",
-      "import": "./src/index.js",
-      "library": Object {
-        "type": "commonjs2",
-      },
-    },
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },

--- a/packages/toolkit/config/__tests__/__snapshots__/webpack-fast-refresh.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack-fast-refresh.js.snap
@@ -26,9 +26,7 @@ Object {
     },
   },
   "devtool": "source-map",
-  "entry": Object {
-    "entry1": "entry1.js",
-  },
+  "entry": () => getEntryPoints(config),
   "experiments": Object {
     "outputModule": false,
   },

--- a/packages/toolkit/config/webpack.config.js
+++ b/packages/toolkit/config/webpack.config.js
@@ -54,7 +54,9 @@ module.exports = {
 	devtool: isProduction ? false : 'source-map',
 	mode,
 	devServer: getDevServer(config),
-	entry: getEntryPoints(config),
+	// using a function here in order to re-evaluate
+	// the entrypoints whenever something changes
+	entry: () => getEntryPoints(config),
 	output: getOutput(config),
 	target: getTarget(config),
 	resolve: getResolve(config),

--- a/packages/toolkit/config/webpack/entry.js
+++ b/packages/toolkit/config/webpack/entry.js
@@ -23,45 +23,52 @@ module.exports = ({
 
 		// add any additional entrypoints we find in block.json filed to the webpack config
 		additionalEntrypoints = blockMetadataFiles.reduce((accumulator, blockMetadataFile) => {
-			// get all assets from the block.json file
-			const { editorScript, script, viewScript, style, editorStyle } = JSON.parse(
-				readFileSync(blockMetadataFile),
-			);
+			// wrapping in try/catch in case the file is malformed
+			// this happens especially when new block.json files are added
+			// at which point they are completely empty and therefore not valid JSON
+			try {
+				// get all assets from the block.json file
+				const { editorScript, script, viewScript, style, editorStyle } = JSON.parse(
+					readFileSync(blockMetadataFile),
+				);
 
-			// generate a new entrypoint for each of the assets
-			[editorScript, script, viewScript, style, editorStyle]
-				.flat()
-				.filter((rawFilepath) => rawFilepath && rawFilepath.startsWith('file:')) // assets can be files or handles. we only want files
-				.forEach((rawFilepath) => {
-					// Removes the `file:` prefix.
-					const filepath = join(
-						dirname(blockMetadataFile),
-						rawFilepath.replace('file:', ''),
-					);
+				// generate a new entrypoint for each of the assets
+				[editorScript, script, viewScript, style, editorStyle]
+					.flat()
+					.filter((rawFilepath) => rawFilepath && rawFilepath.startsWith('file:')) // assets can be files or handles. we only want files
+					.forEach((rawFilepath) => {
+						// Removes the `file:` prefix.
+						const filepath = join(
+							dirname(blockMetadataFile),
+							rawFilepath.replace('file:', ''),
+						);
 
-					// get the entrypoint name from the filepath by removing the blocks source directory and the file extension
-					const entryName = filepath
-						.replace(extname(filepath), '')
-						.replace(blocksSourceDirectory, '')
-						.replace(/\\/g, '/');
+						// get the entrypoint name from the filepath by removing the blocks source directory and the file extension
+						const entryName = filepath
+							.replace(extname(filepath), '')
+							.replace(blocksSourceDirectory, '')
+							.replace(/\\/g, '/');
 
-					// Detects the proper file extension used in the defined source directory.
-					const [entryFilepath] = glob(
-						`${blocksSourceDirectory}/${entryName}.([jt]s?(x)|?(s)css)`,
-						{
-							absolute: true,
-						},
-					);
+						// Detects the proper file extension used in the defined source directory.
+						const [entryFilepath] = glob(
+							`${blocksSourceDirectory}/${entryName}.([jt]s?(x)|?(s)css)`,
+							{
+								absolute: true,
+							},
+						);
 
-					if (!entryFilepath) {
-						// eslint-disable-next-line no-console
-						console.warn('There was no entry file found for', entryName);
-						return;
-					}
+						if (!entryFilepath) {
+							// eslint-disable-next-line no-console
+							console.warn('There was no entry file found for', entryName);
+							return;
+						}
 
-					accumulator[entryName] = entryFilepath;
-				});
-			return accumulator;
+						accumulator[entryName] = entryFilepath;
+					});
+				return accumulator;
+			} catch (error) {
+				return accumulator;
+			}
 		}, {});
 	}
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->
  
Follow up of #195 

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

Before this change adding new `block.json` files whilst the watch mode of toolkit is active resulted in the watch script failing and or not adding the new blocks. Which is a frustrating experience for anyone using it. This has now been fixed.

<!-- Enter any applicable Issues here. Example: -->


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.
- [x] I have added a changeset to my PR. See [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document for instructions
