### PR TITLE
fix how block assets get handled for editor styles

### DIFF
--- a/.changeset/nervous-teachers-push.md
+++ b/.changeset/nervous-teachers-push.md
@@ -1,0 +1,5 @@
+---
+"10up-toolkit": patch
+---
+
+fix how block editor styles get handled if useBlockAssets option is not set

--- a/packages/toolkit/config/webpack/plugins.js
+++ b/packages/toolkit/config/webpack/plugins.js
@@ -103,9 +103,11 @@ module.exports = ({
 					return removeDistFolder(style);
 				}
 
-				return buildFiles[options.chunk.name].match(/\/blocks\//)
-					? filenames.blockCSS
-					: filenames.css;
+				const isBlockAsset = useBlockAssets
+					? buildFiles[options.chunk.name].match(/\/blocks\//)
+					: options.chunk.name.match(/-block$/);
+
+				return isBlockAsset ? filenames.blockCSS : filenames.css;
 			},
 			chunkFilename: '[id].css',
 		}),


### PR DESCRIPTION
Fixes a regression in 4.2 where editor styles of blocks that don't use the new block asset handling mechanism don't get output the same as before. 