### PR TITLE
Sass compatibility improvement

### DIFF
--- a/.changeset/nice-radios-sing.md
+++ b/.changeset/nice-radios-sing.md
@@ -2,4 +2,7 @@
 "10up-toolkit": patch
 ---
 
-Improve Sass compatibility by making sure PostCSS runs after Sass has finished and also ensuring that PostCSS process the Sass pipeline
+Improve Sass compatibility by making sure PostCSS runs after Sass has finished and also ensuring that PostCSS process the Sass pipeline.
+
+Fixes #198
+Fixes #228

--- a/.changeset/nice-radios-sing.md
+++ b/.changeset/nice-radios-sing.md
@@ -1,0 +1,5 @@
+---
+"10up-toolkit": patch
+---
+
+Improve Sass compatibility by making sure PostCSS runs after Sass has finished and also ensuring that PostCSS process the Sass pipeline

--- a/package-lock.json
+++ b/package-lock.json
@@ -5331,7 +5331,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001323",
+      "version": "1.0.30001420",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001420.tgz",
+      "integrity": "sha512-OnyeJ9ascFA9roEj72ok2Ikp7PHJTKubtEJIQ/VK3fdsS50q4KWy+Z5X0A1/GswEItKX0ctAp8n4SYDE7wTu6A==",
       "funding": [
         {
           "type": "opencollective",
@@ -5341,8 +5343,7 @@
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -15499,7 +15500,7 @@
     },
     "packages/toolkit": {
       "name": "10up-toolkit",
-      "version": "4.2.2-next.1",
+      "version": "4.2.2",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": "^7.17.8",
@@ -15583,7 +15584,7 @@
       },
       "devDependencies": {
         "@wordpress/env": "^5.0.0",
-        "10up-toolkit": "^4.2.2-next.1"
+        "10up-toolkit": "^4.2.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -15600,7 +15601,7 @@
         "@testing-library/dom": "^7.29.4",
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/user-event": "^12.6.3",
-        "10up-toolkit": "^4.2.2-next.1",
+        "10up-toolkit": "^4.2.2",
         "jest-axe": "^4.1.0"
       }
     },
@@ -15612,7 +15613,7 @@
         "xss": "^1.0.11"
       },
       "devDependencies": {
-        "10up-toolkit": "^4.2.2-next.1"
+        "10up-toolkit": "^4.2.2"
       }
     },
     "projects/library/node_modules/@testing-library/dom": {
@@ -15926,7 +15927,7 @@
         "@testing-library/dom": "^7.29.4",
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/user-event": "^12.6.3",
-        "10up-toolkit": "^4.2.2-next.1",
+        "10up-toolkit": "^4.2.2",
         "jest-axe": "^4.1.0",
         "xss": "1.0.11"
       },
@@ -16217,7 +16218,7 @@
     "@10up/library-ts-test": {
       "version": "file:projects/library-ts",
       "requires": {
-        "10up-toolkit": "^4.2.2-next.1",
+        "10up-toolkit": "^4.2.2",
         "xss": "^1.0.11"
       }
     },
@@ -19535,7 +19536,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001323"
+      "version": "1.0.30001420",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001420.tgz",
+      "integrity": "sha512-OnyeJ9ascFA9roEj72ok2Ikp7PHJTKubtEJIQ/VK3fdsS50q4KWy+Z5X0A1/GswEItKX0ctAp8n4SYDE7wTu6A=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -24878,7 +24881,7 @@
       "requires": {
         "@10up/component-accordion": "^2.1.5",
         "@wordpress/env": "^5.0.0",
-        "10up-toolkit": "^4.2.2-next.1",
+        "10up-toolkit": "^4.2.2",
         "normalize.css": "^8.0.1",
         "prop-types": "^15.7.2"
       }

--- a/packages/toolkit/config/__tests__/__snapshots__/webpack-basic-config.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack-basic-config.js.snap
@@ -79,6 +79,12 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
+            },
+          },
         ],
       },
       Object {
@@ -97,15 +103,15 @@ Object {
             },
           },
           Object {
-            "loader": "/node_modules/postcss-loader/dist/cjs.js",
-            "options": Object {
-              "postcssOptions": Object {},
-            },
-          },
-          Object {
             "loader": "/node_modules/sass-loader/dist/cjs.js",
             "options": Object {
               "sourceMap": true,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
             },
           },
         ],
@@ -245,6 +251,12 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
+            },
+          },
         ],
       },
       Object {
@@ -263,15 +275,15 @@ Object {
             },
           },
           Object {
-            "loader": "/node_modules/postcss-loader/dist/cjs.js",
-            "options": Object {
-              "postcssOptions": Object {},
-            },
-          },
-          Object {
             "loader": "/node_modules/sass-loader/dist/cjs.js",
             "options": Object {
               "sourceMap": true,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
             },
           },
         ],
@@ -440,6 +452,14 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {
+                "config": "/config/postcss.config.js",
+              },
+            },
+          },
         ],
       },
       Object {
@@ -458,17 +478,17 @@ Object {
             },
           },
           Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+          Object {
             "loader": "/node_modules/postcss-loader/dist/cjs.js",
             "options": Object {
               "postcssOptions": Object {
                 "config": "/config/postcss.config.js",
               },
-            },
-          },
-          Object {
-            "loader": "/node_modules/sass-loader/dist/cjs.js",
-            "options": Object {
-              "sourceMap": true,
             },
           },
         ],
@@ -631,6 +651,14 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {
+                "config": "/config/postcss.config.js",
+              },
+            },
+          },
         ],
       },
       Object {
@@ -649,17 +677,17 @@ Object {
             },
           },
           Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+          Object {
             "loader": "/node_modules/postcss-loader/dist/cjs.js",
             "options": Object {
               "postcssOptions": Object {
                 "config": "/config/postcss.config.js",
               },
-            },
-          },
-          Object {
-            "loader": "/node_modules/sass-loader/dist/cjs.js",
-            "options": Object {
-              "sourceMap": true,
             },
           },
         ],
@@ -823,6 +851,14 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {
+                "config": "/config/postcss.config.js",
+              },
+            },
+          },
         ],
       },
       Object {
@@ -841,17 +877,17 @@ Object {
             },
           },
           Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+          Object {
             "loader": "/node_modules/postcss-loader/dist/cjs.js",
             "options": Object {
               "postcssOptions": Object {
                 "config": "/config/postcss.config.js",
               },
-            },
-          },
-          Object {
-            "loader": "/node_modules/sass-loader/dist/cjs.js",
-            "options": Object {
-              "sourceMap": true,
             },
           },
         ],
@@ -1013,6 +1049,14 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {
+                "config": "/config/postcss.config.js",
+              },
+            },
+          },
         ],
       },
       Object {
@@ -1031,17 +1075,17 @@ Object {
             },
           },
           Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+          Object {
             "loader": "/node_modules/postcss-loader/dist/cjs.js",
             "options": Object {
               "postcssOptions": Object {
                 "config": "/config/postcss.config.js",
               },
-            },
-          },
-          Object {
-            "loader": "/node_modules/sass-loader/dist/cjs.js",
-            "options": Object {
-              "sourceMap": true,
             },
           },
         ],

--- a/packages/toolkit/config/__tests__/__snapshots__/webpack-cli-arguments.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack-cli-arguments.js.snap
@@ -103,6 +103,14 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {
+                "config": "/config/postcss.config.js",
+              },
+            },
+          },
         ],
       },
       Object {
@@ -121,17 +129,17 @@ Object {
             },
           },
           Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+          Object {
             "loader": "/node_modules/postcss-loader/dist/cjs.js",
             "options": Object {
               "postcssOptions": Object {
                 "config": "/config/postcss.config.js",
               },
-            },
-          },
-          Object {
-            "loader": "/node_modules/sass-loader/dist/cjs.js",
-            "options": Object {
-              "sourceMap": true,
             },
           },
         ],
@@ -272,6 +280,12 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
+            },
+          },
         ],
       },
       Object {
@@ -290,15 +304,15 @@ Object {
             },
           },
           Object {
-            "loader": "/node_modules/postcss-loader/dist/cjs.js",
-            "options": Object {
-              "postcssOptions": Object {},
-            },
-          },
-          Object {
             "loader": "/node_modules/sass-loader/dist/cjs.js",
             "options": Object {
               "sourceMap": true,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
             },
           },
         ],
@@ -445,6 +459,12 @@ Object {
               "sourceMap": false,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
+            },
+          },
         ],
       },
       Object {
@@ -463,15 +483,15 @@ Object {
             },
           },
           Object {
-            "loader": "/node_modules/postcss-loader/dist/cjs.js",
-            "options": Object {
-              "postcssOptions": Object {},
-            },
-          },
-          Object {
             "loader": "/node_modules/sass-loader/dist/cjs.js",
             "options": Object {
               "sourceMap": false,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
             },
           },
         ],
@@ -618,6 +638,12 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
+            },
+          },
         ],
       },
       Object {
@@ -636,15 +662,15 @@ Object {
             },
           },
           Object {
-            "loader": "/node_modules/postcss-loader/dist/cjs.js",
-            "options": Object {
-              "postcssOptions": Object {},
-            },
-          },
-          Object {
             "loader": "/node_modules/sass-loader/dist/cjs.js",
             "options": Object {
               "sourceMap": true,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
             },
           },
         ],
@@ -813,6 +839,14 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {
+                "config": "/config/postcss.config.js",
+              },
+            },
+          },
         ],
       },
       Object {
@@ -831,17 +865,17 @@ Object {
             },
           },
           Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+          Object {
             "loader": "/node_modules/postcss-loader/dist/cjs.js",
             "options": Object {
               "postcssOptions": Object {
                 "config": "/config/postcss.config.js",
               },
-            },
-          },
-          Object {
-            "loader": "/node_modules/sass-loader/dist/cjs.js",
-            "options": Object {
-              "sourceMap": true,
             },
           },
         ],
@@ -1004,6 +1038,14 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {
+                "config": "/config/postcss.config.js",
+              },
+            },
+          },
         ],
       },
       Object {
@@ -1022,17 +1064,17 @@ Object {
             },
           },
           Object {
+            "loader": "/node_modules/sass-loader/dist/cjs.js",
+            "options": Object {
+              "sourceMap": true,
+            },
+          },
+          Object {
             "loader": "/node_modules/postcss-loader/dist/cjs.js",
             "options": Object {
               "postcssOptions": Object {
                 "config": "/config/postcss.config.js",
               },
-            },
-          },
-          Object {
-            "loader": "/node_modules/sass-loader/dist/cjs.js",
-            "options": Object {
-              "sourceMap": true,
             },
           },
         ],

--- a/packages/toolkit/config/__tests__/__snapshots__/webpack-fast-refresh.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack-fast-refresh.js.snap
@@ -99,6 +99,12 @@ Object {
               "sourceMap": true,
             },
           },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
+            },
+          },
         ],
       },
       Object {
@@ -117,15 +123,15 @@ Object {
             },
           },
           Object {
-            "loader": "/node_modules/postcss-loader/dist/cjs.js",
-            "options": Object {
-              "postcssOptions": Object {},
-            },
-          },
-          Object {
             "loader": "/node_modules/sass-loader/dist/cjs.js",
             "options": Object {
               "sourceMap": true,
+            },
+          },
+          Object {
+            "loader": "/node_modules/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": Object {},
             },
           },
         ],

--- a/packages/toolkit/config/webpack/modules.js
+++ b/packages/toolkit/config/webpack/modules.js
@@ -103,7 +103,7 @@ module.exports = ({
 							sourceMap: !isProduction,
 							url: isPackage,
 						},
-						postcss: false,
+						postcss: true,
 						sass: true,
 					}),
 				],

--- a/packages/toolkit/config/webpack/modules.js
+++ b/packages/toolkit/config/webpack/modules.js
@@ -11,6 +11,12 @@ const getCSSLoaders = ({ options, postcss, sass }) => {
 			loader: require.resolve('css-loader'),
 			options,
 		},
+		sass && {
+			loader: require.resolve('sass-loader'),
+			options: {
+				sourceMap: options ? options.sourceMap : false,
+			},
+		},
 		postcss && {
 			loader: require.resolve('postcss-loader'),
 			options: {
@@ -21,12 +27,6 @@ const getCSSLoaders = ({ options, postcss, sass }) => {
 						config: fromConfigRoot('postcss.config.js'),
 					}),
 				},
-			},
-		},
-		sass && {
-			loader: require.resolve('sass-loader'),
-			options: {
-				sourceMap: options ? options.sourceMap : false,
 			},
 		},
 	].filter(Boolean);


### PR DESCRIPTION
Fixes #198
Fixes #228 

### Description of the Change

This basically makes PostCSS run after Sass has finished and it also lets PostCSS runs with Sass files (which wasn't done before) leveraging any of the plugins to the Sass pipeline too.

I couldn't replicate the issues with #228 given that there are more plugins there so I couldn't really craft any meaningful tests but this should take care of everything.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [X] All new and existing tests passed.
- [X] I have added a changeset to my PR. See [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document for instructions
