### PR TITLE
Consolidating package meta

### DIFF
--- a/.changeset/slow-cooks-care.md
+++ b/.changeset/slow-cooks-care.md
@@ -1,0 +1,7 @@
+---
+"@10up/babel-preset-default": patch
+"@10up/eslint-config": patch
+"@10up/stylelint-config": patch
+---
+
+Updating package.json links to point to the new repository

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -18,12 +18,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/10up/babel-preset-default.git"
+    "url": "git+https://github.com/10up/10up-toolkit.git",
+    "directory": "packages/babel-preset-default"
   },
   "bugs": {
-    "url": "https://github.com/10up/babel-preset-default/issues"
+    "url": "https://github.com/10up/10up-toolkit/issues"
   },
-  "homepage": "https://github.com/10up/babel-preset-default#readme",
+  "homepage": "https://github.com/10up/10up-toolkit/tree/develop/packages/babel-preset-default#readme",
   "dependencies": {
     "@babel/core": "^7.16.0",
     "@babel/helper-plugin-utils": "^7.14.5",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -23,14 +23,15 @@
   },
   "repository": {
 	"type": "git",
-	"url": "git+https://github.com/10up/eslint-config.git"
+	"url": "git+https://github.com/10up/10up-toolkit.git",
+	"directory": "packages/eslint-config"
   },
   "bugs": {
-	"url": "https://github.com/10up/eslint-config/issues"
+	"url": "https://github.com/10up/10up-toolkit/issues"
   },
   "author": "10up <info@10up.com> (https://10up.com)",
   "license": "GPL-2.0-or-later",
-  "homepage": "https://github.com/10up/eslint-config#readme",
+  "homepage": "https://github.com/10up/10up-toolkit/tree/develop/packages/eslint-config#readme",
   "keywords": [
 	"eslint",
 	"eslint-config",
@@ -62,7 +63,7 @@
   },
   "peerDependenciesMeta": {
 	"@wordpress/eslint-plugin": {
-		"optional": true
+	  "optional": true
 	}
   }
 }

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -6,7 +6,8 @@
   "homepage": "https://github.com/10up/10up-toolkit/tree/develop/packages/stylelint-config#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/10up/10up-toolkit.git"
+    "url": "https://github.com/10up/10up-toolkit.git",
+    "directory": "packages/stylelint-config"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Consolidates package meta information. I don't think this merits a release per see but it's good to have them fixed and not pointing to archived repos.

Given our discussion with package.json I thought it'd be good to take that opportunity there!