### PR TITLE
Ensuring SCSS rules also ignore mixin and define-mixin

### DIFF
--- a/.changeset/early-news-fail.md
+++ b/.changeset/early-news-fail.md
@@ -1,0 +1,5 @@
+---
+"@10up/stylelint-config": patch
+---
+
+Ensure SCSS config accepts mixin at-rules from postcss-mixins

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -13,5 +13,6 @@ module.exports = {
 		'selector-nested-pattern': ['^&'],
 		'no-descending-specificity': null,
 		'at-rule-no-unknown': [true, { ignoreAtRules: ['mixin', 'define-mixin'] }],
+		'scss/at-rule-no-unknown': [true, { ignoreAtRules: ['mixin', 'define-mixin'] }],
 	},
 };


### PR DESCRIPTION
 Fixes #226

### Description of the Change

Updates Stylelint so it accepts `@mixin` and `@define-mixin` on SCSS too.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
- [X] I have added a changeset to my PR. See [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document for instructions
