### PR TITLE
entry module madness

### DIFF
--- a/packages/toolkit/config/webpack/plugins.js
+++ b/packages/toolkit/config/webpack/plugins.js
@@ -103,12 +103,18 @@ module.exports = ({
 					return removeDistFolder(style);
 				}
 
-				// with the react fast refresh plugin
-				// we cannot always assume there's a single entry module
-				// so we need to check if any of the entry modules are relative to blocksSourceDiretory
-				const entryModules = options.chunk.getModules().filter((module) => {
-					return module.isEntryModule();
-				});
+				let entryModules = [];
+				try {
+					// with the react fast refresh plugin
+					// we cannot always assume there's a single entry module
+					// so we need to check if any of the entry modules are relative to blocksSourceDiretory
+					entryModules = options.chunk.getModules().filter((module) => {
+						return module.isEntryModule();
+					});
+				} catch (e) {
+					// if it failed it's bc there's only one entryModule
+					entryModules.push(options.chunk.entryModule);
+				}
 
 				let isBlockAsset = entryModules.some((module) => {
 					const fullPath = module.resource;

--- a/packages/toolkit/config/webpack/plugins.js
+++ b/packages/toolkit/config/webpack/plugins.js
@@ -112,8 +112,12 @@ module.exports = ({
 						return module.isEntryModule();
 					});
 				} catch (e) {
-					// if it failed it's bc there's only one entryModule
-					entryModules.push(options.chunk.entryModule);
+					try {
+						// if it failed it's bc there's only one entryModule
+						entryModules.push(options.chunk.entryModule);
+					} catch (e) {
+						entryModules = [];
+					}
 				}
 
 				let isBlockAsset = entryModules.some((module) => {

--- a/packages/toolkit/config/webpack/plugins.js
+++ b/packages/toolkit/config/webpack/plugins.js
@@ -103,14 +103,23 @@ module.exports = ({
 					return removeDistFolder(style);
 				}
 
-				const fullPath = options.chunk.entryModule.resource;
+				// with the react fast refresh plugin
+				// we cannot always assume there's a single entry module
+				// so we need to check if any of the entry modules are relative to blocksSourceDiretory
+				const entryModules = options.chunk.getModules().filter((module) => {
+					return module.isEntryModule();
+				});
 
-				let isBlockAsset = fullPath
-					? !path
-							.relative(blocksSourceDirectory, fullPath)
-							// startWith('../') but in a cross-env way
-							.startsWith(path.join('..', '/'))
-					: false;
+				let isBlockAsset = entryModules.some((module) => {
+					const fullPath = module.resource;
+
+					return fullPath
+						? !path
+								.relative(blocksSourceDirectory, fullPath)
+								// startWith('../') but in a cross-env way
+								.startsWith(path.join('..', '/'))
+						: false;
+				});
 
 				if (!isBlockAsset) {
 					if (useBlockAssets) {


### PR DESCRIPTION
This fixes `10up-toolkit watch --hot` but breaks `10up-toolkit build`

Regular builds throws the following error:
```
ERROR in [entry] [initial]
Module.isEntryModule: There was no ChunkGraph assigned to the Module for backward-compat (Use the new API)`
```

It keeps telling to use the new API which I have no idea which one is.

UPDATE: added a workaround using try/catch.