### PR TITLE
Updating rule to work with WP style

### DIFF
--- a/.changeset/sixty-seas-chew.md
+++ b/.changeset/sixty-seas-chew.md
@@ -2,4 +2,5 @@
 "@10up/stylelint-config": patch
 ---
 
-Fixes validation for --wp--some--property for custom properties
+Fixes validation for `--wp--some--property` for custom properties
+Fixes usage of `currentcolor` vs `currentColor`

--- a/.changeset/sixty-seas-chew.md
+++ b/.changeset/sixty-seas-chew.md
@@ -1,0 +1,5 @@
+---
+"@10up/stylelint-config": patch
+---
+
+Fixes validation for --wp--some--property for custom properties

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -13,5 +13,11 @@ module.exports = {
 		'selector-nested-pattern': ['^&'],
 		'no-descending-specificity': null,
 		'at-rule-no-unknown': [true, { ignoreAtRules: ['mixin', 'define-mixin'] }],
+		'custom-property-pattern': [
+			'^([a-z][a-z0-9]*)(-[a-z0-9]+)*$|^wp--([a-z][a-z0-9]*)(--[a-z0-9]+)*$',
+			{
+				message: 'Expected custom property name to be kebab-case or wp--kebab--case',
+			},
+		],
 	},
 };

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -4,7 +4,7 @@ module.exports = {
 	rules: {
 		'scale-unlimited/declaration-strict-value': [
 			'/color/',
-			{ ignoreValues: ['currentColor', 'inherit', 'initial', 'transparent', 'unset'] },
+			{ ignoreValues: ['currentcolor', 'inherit', 'initial', 'transparent', 'unset'] },
 		],
 		'order/properties-alphabetical-order': true,
 		'function-url-quotes': 'always',


### PR DESCRIPTION
Related Issue/RFC: #300

### Description of the Change

This updates the `custom-property-pattern` rule being set [here](https://github.com/stylelint/stylelint-config-standard/blob/main/index.js#L49) so it accepts the custom `wp` notation. It's a bit ugly but it validates this

```css
.foo {
  color: var(--foo-bar); /* Valid. Normal kebab-case */
  color: var(--fooBar); /* Invalid. CamelCase */
  color: var(--foo_bar); /* Invalid. Snake_case */
  color: var(--foo--bar); /* Invalid. Double hyphen */
  color: var(--wp--foo--bar); /* Valid. Double hyphen with wp-- prefix */
  color: var(--wp--foo-bar); /* Invalid. Does not follow wp-- convention */
}
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.
- [X] I have added a changeset to my PR. See [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document for instructions
