### PR TITLE
fix: install @wordpress/eslint-plugin  in toolkit by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1475,7 +1475,6 @@
     },
     "node_modules/@babel/plugin-transform-runtime": {
       "version": "7.19.6",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.18.6",
@@ -5663,8 +5662,6 @@
     "node_modules/@wordpress/babel-preset-default": {
       "version": "7.10.0",
       "license": "GPL-2.0-or-later",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.16.0",
         "@babel/plugin-transform-react-jsx": "^7.16.0",
@@ -5686,8 +5683,6 @@
     "node_modules/@wordpress/babel-preset-default/node_modules/@types/react": {
       "version": "18.0.27",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5697,8 +5692,6 @@
     "node_modules/@wordpress/babel-preset-default/node_modules/@types/react-dom": {
       "version": "18.0.10",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -5706,8 +5699,6 @@
     "node_modules/@wordpress/babel-preset-default/node_modules/@wordpress/element": {
       "version": "5.3.0",
       "license": "GPL-2.0-or-later",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@types/react": "^18.0.21",
@@ -5725,8 +5716,6 @@
     "node_modules/@wordpress/babel-preset-default/node_modules/react": {
       "version": "18.2.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5737,8 +5726,6 @@
     "node_modules/@wordpress/babel-preset-default/node_modules/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -5750,8 +5737,6 @@
     "node_modules/@wordpress/babel-preset-default/node_modules/scheduler": {
       "version": "0.23.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -5759,8 +5744,6 @@
     "node_modules/@wordpress/browserslist-config": {
       "version": "5.9.0",
       "license": "GPL-2.0-or-later",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5858,8 +5841,6 @@
     "node_modules/@wordpress/eslint-plugin": {
       "version": "13.10.0",
       "license": "GPL-2.0-or-later",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/eslint-parser": "^7.16.0",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
@@ -5900,8 +5881,6 @@
     "node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-prettier": {
       "version": "3.4.1",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0"
       },
@@ -5921,8 +5900,6 @@
     "node_modules/@wordpress/eslint-plugin/node_modules/globals": {
       "version": "13.13.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -5936,8 +5913,6 @@
     "node_modules/@wordpress/eslint-plugin/node_modules/type-fest": {
       "version": "0.20.2",
       "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5975,8 +5950,6 @@
     "node_modules/@wordpress/prettier-config": {
       "version": "2.9.0",
       "license": "GPL-2.0-or-later",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -6014,8 +5987,6 @@
     "node_modules/@wordpress/warning": {
       "version": "2.26.0",
       "license": "GPL-2.0-or-later",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9427,7 +9398,6 @@
     "node_modules/eslint-config-prettier": {
       "version": "8.6.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9732,7 +9702,6 @@
     "node_modules/eslint-plugin-react-hooks": {
       "version": "4.6.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10449,8 +10418,7 @@
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -16132,7 +16100,6 @@
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-diff": "^1.1.2"
       },
@@ -20872,6 +20839,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.6",
         "@typescript-eslint/parser": "^5.59.6",
         "@wordpress/dependency-extraction-webpack-plugin": "^4.16.0",
+        "@wordpress/eslint-plugin": "13.10.0",
         "@wordpress/jest-console": "^6.11.0",
         "babel-jest": "^27.5.1",
         "babel-loader": "^9.1.2",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -26,6 +26,7 @@
     "@typescript-eslint/parser": "^5.59.6",
     "@wordpress/dependency-extraction-webpack-plugin": "^4.16.0",
     "@wordpress/jest-console": "^6.11.0",
+    "@wordpress/eslint-plugin": "13.10.0",
     "babel-jest": "^27.5.1",
     "babel-loader": "^9.1.2",
     "camelcase": "^6.3.0",


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->
  
Related Issue/RFC: #

### Description of the Change

`@wordpress/eslint-plugin` is an optional peer dep at eslint-config however toolkit must install it since it's what we use by default.

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

<!-- Enter any applicable Issues here. Example: -->


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
- [ ] I have added a changeset to my PR. See [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document for instructions
