### PR TITLE
Fix typos in the HMR and Fast Refresh section of the 10up-toolkit readme

### DIFF
--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -290,15 +290,15 @@ In some setups (such as Laravel Valet), Websocket SSL connections will fail unle
 
 If you aren't already customizing webpack in your project, create a new `webpack.config.js` file in the root of your project/theme. You need to specify the cert, key, and ca properties for the config.devServer.https object.
 
-```
+```js
 const config = require('10up-toolkit/config/webpack.config.js');
-const fs = require('fs')
+const fs = require('fs');
 
 // Customize this to the appropriate path to your certificate folder
-const certPath = '/Users/youruser/.config/valet'
+const certPath = '/Users/youruser/.config/valet';
 
 // Check if devServer is in use and if so, modify the cert files used
-if( typeof config.devServer === 'object ) {
+if( typeof config.devServer === 'object' ) {
   config.devServer.https = {
     key: fs.readFileSync(`${certPath}/Certificates/yoursite.test.key`),
     cert: fs.readFileSync(`${certPath}/Certificates/yoursite.test.crt`),


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->
  
Related Issue/RFC: #364 

### Description of the Change
Fixing syntax errors in the HMR and Fast Refresh section of the toolkit README.md.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
- [ ] I have added a changeset to my PR. See [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document for instructions
