### PR TITLE
Fix: `custom-property-pattern` to also match single `-` separators

### DIFF
--- a/.changeset/funny-dogs-learn.md
+++ b/.changeset/funny-dogs-learn.md
@@ -1,0 +1,5 @@
+---
+"@10up/stylelint-config": patch
+---
+
+Update `custom-property-pattern` regular expression to also match custom properties that use a singular `-` as a group separator

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -25,7 +25,7 @@ module.exports = {
 			},
 		],
 		'custom-property-pattern': [
-			'^([a-z][a-z0-9]*)(-[a-z0-9]+)*$|^wp--([a-z][a-z0-9]*)(--[a-z0-9]+)*$',
+			'^([a-z][a-z0-9]*)(-[a-z0-9]+)*$|^wp--([a-z][a-z0-9]*)([-]{1,2}[a-z0-9]+)*$',
 			{
 				message: 'Expected custom property name to be kebab-case or wp--kebab--case',
 			},


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->
  
Related Issue/RFC: #

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

Update `custom-property-pattern` to also match single `-` separators. This is needed for things like `--wp--preset--font-family--system-font`. The way WordPress generated properties is by adding a single `-` in place of any camelCased variables `camel-case`. Nesting levels get turned to `--`

<!-- Enter any applicable Issues here. Example: -->


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.
- [x] I have added a changeset to my PR. See [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document for instructions
