### PR TITLE
Transform Sass asset file extensions in block.json

### DIFF
--- a/.changeset/hot-worms-compete.md
+++ b/.changeset/hot-worms-compete.md
@@ -1,0 +1,5 @@
+---
+"10up-toolkit": patch
+---
+
+Fix: transform file extension for .sass and .scss assets inside block.json files

--- a/packages/toolkit/utils/__tests__/blocks.js
+++ b/packages/toolkit/utils/__tests__/blocks.js
@@ -162,4 +162,51 @@ describe('transformBlockJson', () => {
 			),
 		);
 	});
+
+	it('transforms sass and scss to css', () => {
+		expect(
+			transformBlockJson(
+				JSON.stringify({
+					style: 'file:./style.sass',
+					editorStyle: 'file:./editor.scss',
+					viewStyle: 'file:./view.sass',
+					version: '12345678',
+				}),
+				absoluteteFileName,
+			),
+		).toEqual(
+			JSON.stringify(
+				{
+					style: 'file:./style.css',
+					editorStyle: 'file:./editor.css',
+					viewStyle: 'file:./view.css',
+					version: '12345678',
+				},
+				null,
+				2,
+			),
+		);
+		expect(
+			transformBlockJson(
+				JSON.stringify({
+					style: ['file:./style.sass', 'file:./style.scss'],
+					editorStyle: ['file:./editor.sass', 'file:./editor.scss'],
+					viewStyle: ['file:./view.sass', 'file:./view.scss'],
+					version: '12345678',
+				}),
+				absoluteteFileName,
+			),
+		).toEqual(
+			JSON.stringify(
+				{
+					style: ['file:./style.css', 'file:./style.css'],
+					editorStyle: ['file:./editor.css', 'file:./editor.css'],
+					viewStyle: ['file:./view.css', 'file:./view.css'],
+					version: '12345678',
+				},
+				null,
+				2,
+			),
+		);
+	});
 });

--- a/packages/toolkit/utils/blocks.js
+++ b/packages/toolkit/utils/blocks.js
@@ -2,11 +2,12 @@ const path = require('path');
 const { getFileContentHash } = require('./file');
 
 const JS_ASSET_KEYS = ['script', 'editorScript', 'viewScript', 'viewScriptModule', 'scriptModule'];
+const CSS_ASSET_KEYS = ['style', 'editorStyle', 'viewStyle'];
 
 /**
  * Transform the asset path from `.ts or .tsx` to `.js`
  *
- * When a block.json file has a script or style property that points to a `.ts or .tsx` file,
+ * When a block.json file has a script property that points to a `.ts or .tsx` file,
  * this function will transform the path to point to the `.js` file instead.
  *
  * @param {string|Array<string>} asset - The asset path to transform
@@ -22,6 +23,30 @@ function transformTSAsset(asset) {
 		// replace the `.ts or .tsx` extension with `.js`
 		const jsPath = filePath.replace(/\.tsx?$/, '.js');
 		return jsPath;
+	}
+
+	return Array.isArray(asset) ? asset.map(replaceExtension) : replaceExtension(asset);
+}
+
+/**
+ * Transform the asset path from `.sass or .scss` to `.css`
+ *
+ * When a block.json file has a style property that points to a `.sass or .scss` file,
+ * this function will transform the path to point to the `.css` file instead.
+ *
+ * @param {string|Array<string>} asset - The asset path to transform
+ * @returns {string|Array<string>}
+ */
+function transformSassAsset(asset) {
+	function replaceExtension(filePath) {
+		const isFilePath = filePath.startsWith('file:');
+		if (!isFilePath) {
+			return filePath;
+		}
+
+		// replace the `.sass or .scss` extension with `.css`
+		const cssPath = filePath.replace(/\.s[ac]ss$/, '.css');
+		return cssPath;
 	}
 
 	return Array.isArray(asset) ? asset.map(replaceExtension) : replaceExtension(asset);
@@ -69,6 +94,12 @@ const transformBlockJson = (content, absoluteFilename) => {
 			newMetadata[key] = transformTSAsset(metadata[key]);
 		}
 	});
+
+	CSS_ASSET_KEYS.forEach((key) => {
+		if (metadata[key]) {
+			newMetadata[key] = transformSassAsset(metadata[key]);
+		}
+	}
 
 	return JSON.stringify(newMetadata, null, 2);
 };

--- a/packages/toolkit/utils/blocks.js
+++ b/packages/toolkit/utils/blocks.js
@@ -99,7 +99,7 @@ const transformBlockJson = (content, absoluteFilename) => {
 		if (metadata[key]) {
 			newMetadata[key] = transformSassAsset(metadata[key]);
 		}
-	}
+	});
 
 	return JSON.stringify(newMetadata, null, 2);
 };


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->
  
Related Issue/RFC: #419

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

When a Sass file is used as a custom block asset, and the asset is set to a `.css` file in block.json, an error is thrown related to automatic version string generation because a file with that name and extension are not available in the source folder.

This PR duplicates the existing functionality that transforms TypeScript asset extensions in block.json for Sass files (.sass/.scss => .css).

block.json input:

```json
{
  "style": "file:./style.scss"
}
```

block.json output:

```json
{
  "style": "file:./style.css"
}
```

<!-- Enter any applicable Issues here. Example: -->


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

I could have changed the way that the version string generator works, but that is much less straightforward than just providing the file that the existing code is looking for (while also following the existing example set by the treatment of TypeScript files).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

I realize that 10up seems to be moving away from Sass, but the workflow still inherently supports it.

A possible, but tiny, drawback is that this will likely change the generated version string in existing projects.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

I verified the fix by running `npm start` in an existing project where I discovered the original issue. I also added and ran the tests successfully.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.
- [x] I have added a changeset to my PR. See [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document for instructions
