### PR TITLE
Fix include `viewStyle` assets in dynamic version generation

### DIFF
--- a/.changeset/nervous-berries-speak.md
+++ b/.changeset/nervous-berries-speak.md
@@ -1,0 +1,5 @@
+---
+"10up-toolkit": patch
+---
+
+Fix include `viewStyle` assets in dynamic version generation

--- a/packages/toolkit/__tests__/build-project-use-block-assets/__fixtures__/includes/blocks/example/block.json
+++ b/packages/toolkit/__tests__/build-project-use-block-assets/__fixtures__/includes/blocks/example/block.json
@@ -39,5 +39,6 @@
 		}
 	},
 	"editorScript": "file:./index.js",
-	"editorStyle": "file:./editor-styles.css"
+	"editorStyle": "file:./editor-styles.css",
+	"viewStyle": "file:./view.css"
 }

--- a/packages/toolkit/__tests__/build-project-use-block-assets/__fixtures__/includes/blocks/example/view.css
+++ b/packages/toolkit/__tests__/build-project-use-block-assets/__fixtures__/includes/blocks/example/view.css
@@ -1,0 +1,5 @@
+/* view.css */
+
+html {
+  background-color: #f00;
+}

--- a/packages/toolkit/__tests__/build-project-use-block-assets/test.js
+++ b/packages/toolkit/__tests__/build-project-use-block-assets/test.js
@@ -51,4 +51,13 @@ describe('build a project (with useBlockAssets)', () => {
 			fs.existsSync(path.join(__dirname, 'dist', 'blocks', 'example', 'editor-styles.css')),
 		).toBeTruthy();
 	});
+
+	it('generates version when using style/viewStyle', () => {
+		const blockJson = JSON.parse(
+			fs
+				.readFileSync(path.join(__dirname, 'dist', 'blocks', 'example', 'block.json'))
+				.toString(),
+		);
+		expect(blockJson).toMatchObject({ version: expect.String });
+	});
 });

--- a/packages/toolkit/__tests__/build-project-use-block-assets/test.js
+++ b/packages/toolkit/__tests__/build-project-use-block-assets/test.js
@@ -58,6 +58,8 @@ describe('build a project (with useBlockAssets)', () => {
 				.readFileSync(path.join(__dirname, 'dist', 'blocks', 'example', 'block.json'))
 				.toString(),
 		);
-		expect(blockJson).toMatchObject({ version: expect.String });
+		expect(blockJson).toMatchObject({
+			version: 'c5b9d82d328781bf3f4a5c8f19dfb700494821c2b514b7e5e724154f1eea10eb',
+		});
 	});
 });

--- a/packages/toolkit/__tests__/build-project/__fixtures__/includes/blocks/example/block.json
+++ b/packages/toolkit/__tests__/build-project/__fixtures__/includes/blocks/example/block.json
@@ -40,4 +40,3 @@
 	},
 	"editorScript": "file:../../../../dist/editor.js",
 	"editorStyle": "file:../../../../dist/editor.css"
-}

--- a/packages/toolkit/utils/blocks.js
+++ b/packages/toolkit/utils/blocks.js
@@ -58,9 +58,11 @@ const transformBlockJson = (content, absoluteFilename) => {
 		return content;
 	}
 	const metadata = JSON.parse(rawMetadata);
-	const { version, style } = metadata;
+	const { version, style = [], viewStyle = [] } = metadata;
 
 	const styleArray = Array.isArray(style) ? style : [style];
+	const viewStyleArray = Array.isArray(viewStyle) ? viewStyle : [viewStyle];
+	const combinedStylesArray = [...styleArray, ...viewStyleArray];
 
 	// check whether the style property is defined and a local file path
 	const isFilePath = styleArray?.some((styleName) => styleName?.startsWith('file:'));
@@ -71,7 +73,7 @@ const transformBlockJson = (content, absoluteFilename) => {
 	let styleFileContentHash = '';
 
 	if (!hasVersion && isFilePath) {
-		styleArray.forEach((rawStylePath) => {
+		combinedStylesArray.forEach((rawStylePath) => {
 			if (!rawStylePath.startsWith('file:')) {
 				return;
 			}

--- a/packages/toolkit/utils/blocks.js
+++ b/packages/toolkit/utils/blocks.js
@@ -65,7 +65,12 @@ const transformBlockJson = (content, absoluteFilename) => {
 	const combinedStylesArray = [...styleArray, ...viewStyleArray];
 
 	// check whether the style property is defined and a local file path
-	const isFilePath = styleArray?.some((styleName) => styleName?.startsWith('file:'));
+	const styleHasFilePath = styleArray?.some((styleName) => styleName?.startsWith('file:'));
+	const viewStyleHasFilePath = viewStyleArray?.some((viewStyleName) =>
+		viewStyleName?.startsWith('file:'),
+	);
+	const isFilePath = styleHasFilePath || viewStyleHasFilePath;
+
 	const hasVersion = version !== undefined;
 
 	const absoluteDirectory = absoluteFilename.replace(/block\.json$/, '');


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->
  

### Description of the Change

WordPress uses the `version` property of a `block.json` file as the cache busting property for any style assets that are defined in it. This is okay but means you have to manually update a version parameter every time. If you don't it will use the current WordPress version as a fallback.

In #281 we added some handling to toolkit which automatically generates and injects a version param if there isn't already one defined that consists of a hash of all the assets starting with `file:`. 

This automatically generated `version` currently only accounts for `style` assets. `viewStyle` assets are not handled and therefore don't trigger the version generation. 

This fixes that by also handling `viewStyle` in the same way.

_Props to @smwoll for raising this to me 🚀_
