### PR TITLE
Add callback to `server.close()`

### DIFF
--- a/.changeset/nasty-drinks-talk.md
+++ b/.changeset/nasty-drinks-talk.md
@@ -1,0 +1,5 @@
+---
+"10up-toolkit": minor
+---
+
+Added callback to webpack server.close

--- a/packages/toolkit/scripts/start.js
+++ b/packages/toolkit/scripts/start.js
@@ -77,7 +77,7 @@ if (hot) {
 
 process.on('SIGINT', () => {
 	if (server) {
-		server.close();
+		server.close(() => {});
 	}
 
 	compiler.close();


### PR DESCRIPTION
Adds an empty callback function to silence the webpack error when cancelling the `watch` command.

Reference [here](https://webpack.js.org/migrate/5/#cleanup-the-build-code)

- [X] I have read the [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [X] All new and existing tests passed.
- [ ] I have added a changeset to my PR. See [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document for instructions
