### PR TITLE
fix: typescript eslint plugin dep issue

### DIFF
--- a/.changeset/tidy-coins-wave.md
+++ b/.changeset/tidy-coins-wave.md
@@ -1,0 +1,5 @@
+---
+"10up-toolkit": patch
+---
+
+Pin eslint-plugin-jest to v28 to fix conflict with the `@typescript/eslint-plugin` dep.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13046,10 +13046,10 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.8.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.8.3.tgz",
-      "integrity": "sha512-HIQ3t9hASLKm2IhIOqnu+ifw7uLZkIlR7RYNv7fMcEi/p0CIiJmfriStQS2LDkgtY4nyLbIZAD+JL347Yc2ETQ==",
-      "peer": true,
+      "version": "28.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.14.0.tgz",
+      "integrity": "sha512-P9s/qXSMTpRTerE2FQ0qJet2gKbcGyFTPAJipoKxmWqR6uuFqIqk8FuEfg5yBieOezVrEfAMZrEwJ6yEp+1MFQ==",
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
@@ -28399,7 +28399,7 @@
     },
     "packages/babel-preset-default": {
       "name": "@10up/babel-preset-default",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dependencies": {
         "@babel/core": "^7.23.7",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -28413,7 +28413,7 @@
         "core-js": "^3.35.0"
       },
       "devDependencies": {
-        "@10up/eslint-config": "^4.1.1",
+        "@10up/eslint-config": "^4.1.2",
         "@wordpress/element": "^4.20.0",
         "babel-jest": "^27.5.1",
         "eslint": "^8.40.0",
@@ -28422,10 +28422,10 @@
     },
     "packages/eslint-config": {
       "name": "@10up/eslint-config",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@10up/babel-preset-default": "^2.1.1"
+        "@10up/babel-preset-default": "^2.1.2"
       },
       "devDependencies": {
         "@wordpress/eslint-plugin": "^17.5.0",
@@ -28460,7 +28460,7 @@
     },
     "packages/stylelint-config": {
       "name": "@10up/stylelint-config",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "stylelint-config-recommended": "^13.0.0",
@@ -28469,7 +28469,7 @@
         "stylelint-stylistic": "^0.4.3"
       },
       "devDependencies": {
-        "@10up/eslint-config": "^4.1.1",
+        "@10up/eslint-config": "^4.1.2",
         "jest": "^29.7.0"
       },
       "engines": {
@@ -28481,7 +28481,7 @@
     },
     "packages/toolkit": {
       "name": "10up-toolkit",
-      "version": "6.4.0",
+      "version": "6.4.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/eslint-parser": "^7.23.3",
@@ -28505,6 +28505,7 @@
         "css-loader": "^6.8.1",
         "cssnano": "^6.0.3",
         "error-stack-parser": "^2.1.4",
+        "eslint-plugin-jest": "^28.14.0",
         "eslint-webpack-plugin": "^4.0.1",
         "fast-glob": "^3.3.2",
         "html-webpack-plugin": "^5.6.0",
@@ -28543,9 +28544,9 @@
         "10up-toolkit": "bin/10up-toolkit.js"
       },
       "devDependencies": {
-        "@10up/babel-preset-default": ">=2.1.1",
-        "@10up/eslint-config": ">=4.1.1",
-        "@10up/stylelint-config": ">=3.0.0"
+        "@10up/babel-preset-default": ">=2.1.2",
+        "@10up/eslint-config": ">=4.1.2",
+        "@10up/stylelint-config": ">=3.0.1"
       },
       "engines": {
         "node": ">=16",
@@ -29107,7 +29108,7 @@
         "@linaria/babel-preset": "^5.0.3",
         "@linaria/webpack-loader": "^5.0.3",
         "@wordpress/env": "^10.10.0",
-        "10up-toolkit": "^6.4.0"
+        "10up-toolkit": "^6.4.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -29124,7 +29125,7 @@
         "@testing-library/dom": "9.3.3",
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/user-event": "^14.5.2",
-        "10up-toolkit": "^6.4.0",
+        "10up-toolkit": "^6.4.1",
         "jest-axe": "^8.0.0",
         "jest-environment-jsdom": "~29.7.0"
       }
@@ -29137,7 +29138,7 @@
         "xss": "^1.0.11"
       },
       "devDependencies": {
-        "10up-toolkit": "^6.4.0"
+        "10up-toolkit": "^6.4.1"
       }
     },
     "projects/library/node_modules/@jest/types": {

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -40,6 +40,7 @@
 		"cssnano": "^6.0.3",
 		"error-stack-parser": "^2.1.4",
 		"eslint-webpack-plugin": "^4.0.1",
+		"eslint-plugin-jest": "^28.14.0",
 		"fast-glob": "^3.3.2",
 		"html-webpack-plugin": "^5.6.0",
 		"ignore-emit-webpack-plugin": "^2.0.6",


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->
  
Related Issue/RFC: #443 (partially fixes it)

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

<!-- Enter any applicable Issues here. Example: -->

This pins 10up-toolkit to use eslint-plugin-jest v28 which still works with `@typescript/eslint-plugin` v6

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.
- [x] I have added a changeset to my PR. See [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document for instructions
