### PR TITLE
Fix: HMR for Non-Module Systems

### DIFF
--- a/.changeset/angry-rockets-smash.md
+++ b/.changeset/angry-rockets-smash.md
@@ -1,0 +1,5 @@
+---
+"10up-toolkit": minor
+---
+
+Fix HMR for non-script module based installations and support better peer dependency management

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "restricted",
-  "baseBranch": "trunk",
+  "baseBranch": "develop",
   "updateInternalDependencies": "patch",
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -62,6 +62,8 @@ rm -rf node_modules package-lock.json && npm install
 
 The toolkit declares `webpack-dev-server` as a peer dependency so that your project’s dependency tree controls the version and upgrades are predictable when you run `npm install` after bumping the toolkit (npm 7+ installs peer dependencies automatically).
 
+**Scenarios where an older version can still be used:** Installing with `npm install --legacy-peer-deps` skips peer dependency installation and conflict checks, so an older or transitive copy of `webpack-dev-server` may be used. Pinning an old version in your own `package.json` or having another dependency that depends on an older `webpack-dev-server` can also leave an incompatible version in the tree. In those cases the toolkit will print a warning at runtime; install a matching version (e.g. `webpack-dev-server@^5.2.2`) in your project to clear it.
+
 ### Setting it up
 
 In order to get `10up-toolkit` up and running simply define the `source` and `main` properties in your `package.json` file.

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -43,8 +43,24 @@ npm install --save-dev 10up-toolkit
 If you're using a version of NPM lower than 7 and `10up-toolkit` from version `4.0.0` you'll also need to install the following dependencies manually:
 
 ```bash{showPrompt}
-npm install --save-dev stylelint @10up/stylelint-config @10up/eslint-config @10up/babel-preset-default
+npm install --save-dev stylelint @10up/stylelint-config @10up/eslint-config @10up/babel-preset-default webpack-dev-server
 ```
+
+#### Upgrading the toolkit
+
+When you upgrade `10up-toolkit`, the lock file (`package-lock.json` or `yarn.lock`) may keep an older version of transitive dependencies such as `webpack-dev-server`. If you use the dev server or hot reload and see issues after upgrading, ensure a matching version is installed:
+
+```bash{showPrompt}
+npm update webpack-dev-server
+```
+
+Or reinstall from a clean state:
+
+```bash{showPrompt}
+rm -rf node_modules package-lock.json && npm install
+```
+
+The toolkit declares `webpack-dev-server` as a peer dependency so that your project’s dependency tree controls the version and upgrades are predictable when you run `npm install` after bumping the toolkit (npm 7+ installs peer dependencies automatically).
 
 ### Setting it up
 

--- a/packages/toolkit/config/__tests__/__snapshots__/webpack-fast-refresh.js.snap
+++ b/packages/toolkit/config/__tests__/__snapshots__/webpack-fast-refresh.js.snap
@@ -18,13 +18,14 @@ exports[`webpack.config.js includes react-webpack-fast-refresh with the --hot op
     },
     "hot": true,
     "port": 8000,
-    "proxy": {
-      "/dist": {
+    "proxy": [
+      {
+        "context": "/dist",
         "pathRewrite": {
           "^/dist": "",
         },
       },
-    },
+    ],
   },
   "devtool": "source-map",
   "entry": "() => getEntryPoints({

--- a/packages/toolkit/config/webpack.config.js
+++ b/packages/toolkit/config/webpack.config.js
@@ -1,10 +1,12 @@
 /**
  * Internal dependencies
  */
+const { version: webpackDevServerVersion = '0' } = require('webpack-dev-server');
 const {
 	getBuildFiles,
 	getTenUpScriptsConfig,
 	getTenUpScriptsPackageBuildConfig,
+	isMinimumPackageVersion,
 } = require('../utils');
 const { getModuleBuildFiles } = require('../utils/config');
 
@@ -42,6 +44,20 @@ const defaultTargets = [
 	'not ie_mob <=11',
 ];
 
+const MIN_WDS_VERSION = '5.2.2';
+const useLegacyProxy = !isMinimumPackageVersion(webpackDevServerVersion, MIN_WDS_VERSION);
+const isTestEnv = typeof process.env.JEST_WORKER_ID !== 'undefined';
+
+// Skip warning in tests so snapshot/output isn't noisy; version check and useLegacyProxy still run.
+if (useLegacyProxy && !isTestEnv) {
+	// eslint-disable-next-line no-console -- runtime warning for incompatible peer
+	console.warn(
+		`[10up-toolkit] webpack-dev-server ${webpackDevServerVersion} was resolved; ${MIN_WDS_VERSION} or newer is recommended.\n` +
+			'  If you used --legacy-peer-deps or have an older version in your tree, install a matching version:\n' +
+			'  npm install --save-dev webpack-dev-server@^5.2.2',
+	);
+}
+
 const config = {
 	projectConfig,
 	packageConfig,
@@ -51,6 +67,7 @@ const config = {
 	mode,
 	isProduction,
 	defaultTargets,
+	useLegacyProxy,
 };
 
 const baseConfig = {

--- a/packages/toolkit/config/webpack.config.js
+++ b/packages/toolkit/config/webpack.config.js
@@ -54,7 +54,7 @@ if (useLegacyProxy && !isTestEnv) {
 	console.warn(
 		`[10up-toolkit] webpack-dev-server ${webpackDevServerVersion} was resolved; ${MIN_WDS_VERSION} or newer is recommended.\n` +
 			'  If you used --legacy-peer-deps or have an older version in your tree, install a matching version:\n' +
-			'  npm install --save-dev webpack-dev-server@^5.2.2',
+			`  npm install --save-dev webpack-dev-server@${MIN_WDS_VERSION}`,
 	);
 }
 

--- a/packages/toolkit/config/webpack.config.js
+++ b/packages/toolkit/config/webpack.config.js
@@ -1,9 +1,9 @@
 /**
  * Internal dependencies
  */
-const { version: webpackDevServerVersion = '0' } = require('webpack-dev-server');
 const {
 	getBuildFiles,
+	getInstalledPackageVersion,
 	getTenUpScriptsConfig,
 	getTenUpScriptsPackageBuildConfig,
 	isMinimumPackageVersion,
@@ -45,11 +45,12 @@ const defaultTargets = [
 ];
 
 const MIN_WDS_VERSION = '5.2.2';
-const useLegacyProxy = !isMinimumPackageVersion(webpackDevServerVersion, MIN_WDS_VERSION);
+const isHotReloadEnabled = projectConfig.devServer || projectConfig.hot;
 const isTestEnv = typeof process.env.JEST_WORKER_ID !== 'undefined';
+const webpackDevServerVersion = getInstalledPackageVersion('webpack-dev-server', '0');
+const useLegacyProxy = !isMinimumPackageVersion(webpackDevServerVersion, MIN_WDS_VERSION);
 
-// Skip warning in tests so snapshot/output isn't noisy; version check and useLegacyProxy still run.
-if (useLegacyProxy && !isTestEnv) {
+if (isHotReloadEnabled && useLegacyProxy && !isTestEnv) {
 	// eslint-disable-next-line no-console -- runtime warning for incompatible peer
 	console.warn(
 		`[10up-toolkit] webpack-dev-server ${webpackDevServerVersion} was resolved; ${MIN_WDS_VERSION} or newer is recommended.\n` +

--- a/packages/toolkit/config/webpack/__tests__/devServer.js
+++ b/packages/toolkit/config/webpack/__tests__/devServer.js
@@ -1,4 +1,5 @@
 const externals = require('../externals');
+const getDevServer = require('../devServer');
 
 describe('externals module function', () => {
 	it('returns default externals for project config', () => {
@@ -54,6 +55,73 @@ describe('externals module function', () => {
 		).toEqual({
 			jquery: 'commonjs2 jquery',
 			lodash: 'commonjs2 lodash',
+		});
+	});
+});
+
+describe('devServer', () => {
+	const baseHotOptions = {
+		isPackage: false,
+		isModule: false,
+		projectConfig: {
+			devServer: false,
+			devURL: 'http://example.test',
+			hot: true,
+			devServerPort: 3000,
+		},
+	};
+
+	it('returns undefined when neither devServer nor hot is enabled', () => {
+		expect(
+			getDevServer({
+				...baseHotOptions,
+				projectConfig: { ...baseHotOptions.projectConfig, hot: false },
+			}),
+		).toBeUndefined();
+		expect(
+			getDevServer({
+				isPackage: false,
+				isModule: false,
+				projectConfig: {
+					devServer: false,
+					devURL: 'http://example.test',
+					hot: false,
+					devServerPort: 3000,
+				},
+			}),
+		).toBeUndefined();
+	});
+
+	it('uses array-based proxy configuration (v5 style) when useLegacyProxy is false', () => {
+		const result = getDevServer({ ...baseHotOptions, useLegacyProxy: false });
+		expect(result).toBeDefined();
+		expect(result.proxy).toEqual([
+			{
+				context: '/dist',
+				pathRewrite: {
+					'^/dist': '',
+				},
+			},
+		]);
+	});
+
+	it('uses array-based proxy configuration (v5 style) when useLegacyProxy is omitted', () => {
+		const result = getDevServer(baseHotOptions);
+		expect(result).toBeDefined();
+		expect(Array.isArray(result.proxy)).toBe(true);
+		expect(result.proxy[0]).toHaveProperty('context', '/dist');
+		expect(result.proxy[0].pathRewrite).toEqual({ '^/dist': '' });
+	});
+
+	it('uses object-based proxy configuration (legacy style) when useLegacyProxy is true', () => {
+		const result = getDevServer({ ...baseHotOptions, useLegacyProxy: true });
+		expect(result).toBeDefined();
+		expect(result.proxy).toEqual({
+			'/dist': {
+				pathRewrite: {
+					'^/dist': '',
+				},
+			},
 		});
 	});
 });

--- a/packages/toolkit/config/webpack/devServer.js
+++ b/packages/toolkit/config/webpack/devServer.js
@@ -1,5 +1,16 @@
 // Check for WebPack Dev Server version with fallback
 const { version: webpackDevServerVersion = '0' } = require('webpack-dev-server');
+const { isMinimumPackageVersion } = require('../../utils');
+
+const MIN_WDS_VERSION = '5.2.2';
+if (!isMinimumPackageVersion(webpackDevServerVersion, MIN_WDS_VERSION)) {
+	// eslint-disable-next-line no-console -- runtime warning for incompatible peer
+	console.warn(
+		`[10up-toolkit] webpack-dev-server ${webpackDevServerVersion} was resolved; ${MIN_WDS_VERSION} or newer is recommended.\n` +
+			'  If you used --legacy-peer-deps or have an older version in your tree, install a matching version:\n' +
+			'  npm install --save-dev webpack-dev-server@^5.2.2',
+	);
+}
 
 module.exports = ({
 	isPackage,

--- a/packages/toolkit/config/webpack/devServer.js
+++ b/packages/toolkit/config/webpack/devServer.js
@@ -24,14 +24,22 @@ module.exports = ({
 			// do nothing
 		}
 
-		const distProxyConfiguration = {
+		const distProxyConfiguration = [
+			{
+				context: '/dist',
+				pathRewrite: {
+					'^/dist': '',
+				},
+			},
+		];
+		const legacyProxyConfiguration = {
 			'/dist': {
 				pathRewrite: {
 					'^/dist': '',
 				},
 			},
 		};
-		const proxy = useLegacyProxy ? distProxyConfiguration : [distProxyConfiguration];
+		const proxy = useLegacyProxy ? legacyProxyConfiguration : distProxyConfiguration;
 
 		return {
 			devMiddleware: {

--- a/packages/toolkit/config/webpack/devServer.js
+++ b/packages/toolkit/config/webpack/devServer.js
@@ -1,3 +1,6 @@
+// Check for WebPack Dev Server version with fallback
+const { version: webpackDevServerVersion = '0' } = require('webpack-dev-server');
+
 module.exports = ({
 	isPackage,
 	isModule,
@@ -23,6 +26,19 @@ module.exports = ({
 			// do nothing
 		}
 
+		// If WebPack Dev Service version is v5.x.x, use the new proxy configuration
+		// Supports Toolkit upgrades where WDS was not updated to v5.x.x
+		const distProxyConfiguration = {
+			'/dist': {
+				pathRewrite: {
+					'^/dist': '',
+				},
+			},
+		};
+		const proxy = webpackDevServerVersion.startsWith('5.')
+			? [distProxyConfiguration]
+			: distProxyConfiguration;
+
 		return {
 			devMiddleware: {
 				writeToDisk: true,
@@ -37,13 +53,7 @@ module.exports = ({
 				},
 			},
 			port: Number(devServerPort),
-			proxy: {
-				'/dist': {
-					pathRewrite: {
-						'^/dist': '',
-					},
-				},
-			},
+			proxy,
 		};
 	}
 

--- a/packages/toolkit/config/webpack/devServer.js
+++ b/packages/toolkit/config/webpack/devServer.js
@@ -1,21 +1,8 @@
-// Check for WebPack Dev Server version with fallback
-const { version: webpackDevServerVersion = '0' } = require('webpack-dev-server');
-const { isMinimumPackageVersion } = require('../../utils');
-
-const MIN_WDS_VERSION = '5.2.2';
-if (!isMinimumPackageVersion(webpackDevServerVersion, MIN_WDS_VERSION)) {
-	// eslint-disable-next-line no-console -- runtime warning for incompatible peer
-	console.warn(
-		`[10up-toolkit] webpack-dev-server ${webpackDevServerVersion} was resolved; ${MIN_WDS_VERSION} or newer is recommended.\n` +
-			'  If you used --legacy-peer-deps or have an older version in your tree, install a matching version:\n' +
-			'  npm install --save-dev webpack-dev-server@^5.2.2',
-	);
-}
-
 module.exports = ({
 	isPackage,
 	isModule,
 	projectConfig: { devServer, devURL, hot, devServerPort },
+	useLegacyProxy = false,
 }) => {
 	if (!devServer && !hot) {
 		return undefined;
@@ -37,8 +24,6 @@ module.exports = ({
 			// do nothing
 		}
 
-		// If WebPack Dev Service version is v5.x.x, use the new proxy configuration
-		// Supports Toolkit upgrades where WDS was not updated to v5.x.x
 		const distProxyConfiguration = {
 			'/dist': {
 				pathRewrite: {
@@ -46,9 +31,7 @@ module.exports = ({
 				},
 			},
 		};
-		const proxy = webpackDevServerVersion.startsWith('5.')
-			? [distProxyConfiguration]
-			: distProxyConfiguration;
+		const proxy = useLegacyProxy ? distProxyConfiguration : [distProxyConfiguration];
 
 		return {
 			devMiddleware: {

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -69,7 +69,6 @@
 		"url-loader": "^4.1.1",
 		"webpack": "^5.89.0",
 		"webpack-bundle-analyzer": "^4.10.1",
-		"webpack-dev-server": "^5.2.2",
 		"webpack-sources": "^3.2.3",
 		"webpackbar": "^6.0.0",
 		"yaml": "^2.4.1"
@@ -85,7 +84,8 @@
 		"@10up/stylelint-config": ">=3.0.0",
 		"@linaria/babel-preset": ">=4.3.3",
 		"@linaria/webpack-loader": ">=4.1.11",
-		"typescript": ">=5.0.0"
+		"typescript": ">=5.0.0",
+		"webpack-dev-server": "^5.2.2"
 	},
 	"peerDependenciesMeta": {
 		"@linaria/webpack-loader": {

--- a/packages/toolkit/utils/index.js
+++ b/packages/toolkit/utils/index.js
@@ -29,10 +29,11 @@ const {
 const { fromProjectRoot, fromConfigRoot, hasProjectFile } = require('./file');
 
 const {
-	hasPackageProp,
-	getPackagePath,
+	getInstalledPackageVersion,
 	getPackage,
+	getPackagePath,
 	getPackageVersion,
+	hasPackageProp,
 	isMinimumPackageVersion,
 } = require('./package');
 
@@ -69,6 +70,7 @@ module.exports = {
 	getJestOverrideConfigFile,
 	hasJestConfig,
 	getEnvironmentFromBranch,
+	getInstalledPackageVersion,
 	hasPackageProp,
 	hasPrettierConfig,
 	hasEslintConfig,

--- a/packages/toolkit/utils/index.js
+++ b/packages/toolkit/utils/index.js
@@ -28,7 +28,13 @@ const {
 } = require('./config');
 const { fromProjectRoot, fromConfigRoot, hasProjectFile } = require('./file');
 
-const { hasPackageProp, getPackagePath, getPackage, getPackageVersion } = require('./package');
+const {
+	hasPackageProp,
+	getPackagePath,
+	getPackage,
+	getPackageVersion,
+	isMinimumPackageVersion,
+} = require('./package');
 
 const { displayWebpackStats } = require('./webpack');
 
@@ -79,6 +85,7 @@ module.exports = {
 	getTenUpScriptsPackageBuildConfig,
 	hasWebpackConfig,
 	displayWebpackStats,
+	isMinimumPackageVersion,
 	transformBlockJson,
 	getGitBranch,
 };

--- a/packages/toolkit/utils/package.js
+++ b/packages/toolkit/utils/package.js
@@ -55,7 +55,34 @@ const isPackageInstalled = (packageName) => {
 	return false;
 };
 
+/**
+ * Compares two semver-like version strings (e.g. "5.2.2", "1.0.0-beta.1").
+ * Only the numeric segments are compared; non-numeric segments are treated as 0.
+ *
+ * @param {string} actual - The resolved version (e.g. from a package).
+ * @param {string} min   - The minimum required version.
+ * @returns {boolean} True if actual >= min, false otherwise.
+ */
+const isMinimumPackageVersion = (actual, min) => {
+	const actualVersions = actual.split('.').map(Number);
+	const minimumVersions = min.split('.').map(Number);
+
+	for (let i = 0; i < Math.max(actualVersions.length, minimumVersions.length); i++) {
+		const actualVersionLevel = actualVersions[i] || 0;
+		const minimumVersionLevel = minimumVersions[i] || 0;
+		if (actualVersionLevel > minimumVersionLevel) {
+			return true;
+		}
+		if (actualVersionLevel < minimumVersionLevel) {
+			return false;
+		}
+	}
+
+	return true;
+};
+
 module.exports = {
+	isMinimumPackageVersion,
 	isPackageInstalled,
 	getPackagePath,
 	hasPackageProp,

--- a/packages/toolkit/utils/package.js
+++ b/packages/toolkit/utils/package.js
@@ -39,6 +39,25 @@ const getPackageVersion = async () => {
 };
 
 /**
+ * Returns the version of an installed npm package by name.
+ * Resolves the package's package.json so it works without importing the package.
+ * Uses read-pkg to read and parse the package.json.
+ *
+ * @param {string} packageName - The name of the npm package (e.g. 'webpack-dev-server').
+ * @param {string} [fallback='0'] - Value to return if the package is not installed or version is unreadable.
+ * @returns {string} The package version string or the fallback.
+ */
+const getInstalledPackageVersion = (packageName, fallback = '0') => {
+	try {
+		const pkgPath = require.resolve(`${packageName}/package.json`);
+		const pkg = readPkg.sync({ cwd: path.dirname(pkgPath) });
+		return typeof pkg.version === 'string' ? pkg.version : fallback;
+	} catch {
+		return fallback;
+	}
+};
+
+/**
  * Checks whether the passed package name is installed in the project.
  *
  * @param {string} packageName The name of npm package.
@@ -82,10 +101,11 @@ const isMinimumPackageVersion = (actual, min) => {
 };
 
 module.exports = {
+	getInstalledPackageVersion,
+	getPackage,
+	getPackagePath,
+	getPackageVersion,
+	hasPackageProp,
 	isMinimumPackageVersion,
 	isPackageInstalled,
-	getPackagePath,
-	hasPackageProp,
-	getPackage,
-	getPackageVersion,
 };


### PR DESCRIPTION
Related Issue/RFC: #428

**Important Note**: This does not solve the issue of HMR (--hot) not running with script modules. It does resolve failures for `--hot` to work on projects which use HMR, have upgraded WDS to v5, and have `useScriptModule` and `useBlockAssets` disabled. It also establishes concrete steps to properly upgrade peer dependencies and warn users when manual intervention is required.

### Description of the Change

This PR addresses webpack-dev-server (WDS) compatibility and upgrade behavior for projects using the toolkit’s dev server and hot reload:

1. **webpack-dev-server as peer dependency**
   `webpack-dev-server` is moved from `dependencies` to `peerDependencies` (`^5.2.2`) so the consuming project’s dependency tree owns the version. Upgrade the `10up-toolkit` package and run `npm install` (npm 7+) to resolve the matching WDS version more predictably, which helps avoids keeping an outdated, transitive version in the project lockfile. NPM 7+ will manage peer dependency installation by default.

2. **Correct WDS v5 proxy configuration**
   Hot reload proxy config is updated for webpack-dev-server v5: the proxy is now passed as an **array** of context configs (e.g. `[{ context: '/dist', pathRewrite: { '^/dist': '' } }]`) instead of the v4-style **object** form. A `useLegacyProxy` option is supported so legacy WDS versions can still use the object format.

3. **Version check and warning in config assembly**
   A minimum WDS version check and user-facing warning are  added to `config/webpack.config.js`. The config layer reads the resolved WDS version, computes `useLegacyProxy = !isMinimumPackageVersion(version, '5.2.2')`, and passes `useLegacyProxy` into the devServer helper. The warning is only shown when `useLegacyProxy` is true and the process is not running in Jest (`JEST_WORKER_ID` unset), so test output stays clean.

4. **Shared version helper**
   `isMinimumPackageVersion(actual, min)` is added in `utils/package.js` (and re-exported from `utils`) for semver-style version comparison and reused where the minimum WDS version is enforced.

5. **Documentation**
   README is updated with: an “Upgrading the toolkit” section (lockfile behavior, `npm update webpack-dev-server`, clean reinstall); note that `webpack-dev-server` is a peer dependency; and scenarios where an older version can still be used (e.g. `--legacy-peer-deps`, pinned or transitive old version), with a note that the toolkit will warn at runtime. The npm &lt; 7 manual install list now includes `webpack-dev-server`.

6. **Tests**
   In `config/webpack/__tests__/devServer.js`, new tests validate devServer proxy configuration: undefined when neither devServer nor hot is enabled; array (v5) proxy when `useLegacyProxy` is false or omitted; object (legacy) proxy when `useLegacyProxy` is true.

**Files changed:**

- `packages/toolkit/package.json`
- `packages/toolkit/README.md`
- `packages/toolkit/config/webpack.config.js`
- `packages/toolkit/config/webpack/devServer.js`
- `packages/toolkit/config/webpack/__tests__/devServer.js`
- `packages/toolkit/utils/package.js`
- `packages/toolkit/utils/index.js`.

### Alternate Designs

- **Always warn when useLegacyProxy is true:** We skip the warning when `JEST_WORKER_ID` is set so Jest runs don’t print the warning; the version check and `useLegacyProxy` still run in tests. Alternatively we could mock `webpack-dev-server` in tests to return a 5.x version and keep the warning unconditional in production code.

### Possible Drawbacks

- **Breaking for npm &lt; 7:** Projects on npm &lt; 7 must install `webpack-dev-server` manually (documented in the peer dependency warning and README).
- **Legacy peer / lockfile edge cases:** Using `--legacy-peer-deps` or having an older pinned or transitive `webpack-dev-server` can still result in an old version; we document this and warn at runtime when the resolved version is below the minimum.

### Verification Process

- Ran the toolkit test suite (including `config/__tests__` and `config/webpack/__tests__/devServer.js`) and confirmed all tests pass and no console.warn appears from the version check in tests.
- Confirmed devServer tests cover: undefined when neither devServer nor hot; array proxy when `useLegacyProxy` is false or omitted; object proxy when `useLegacyProxy` is true.
- Manually verified that with a project depending on the toolkit, upgrading the toolkit and running `npm install` (npm 7+) installs a compatible `webpack-dev-server` via the peer dependency.
- Checked that README upgrade instructions and peer dependency / legacy-peer-deps notes are accurate and complete.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.
- [x] I have added a changeset to my PR. See [**CONTRIBUTING**](https://github.com/10up/10up-toolkit/blob/develop/CONTRIBUTING.md) document for instructions
